### PR TITLE
simulate cleanup

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,4 @@
 *.o
 *.ll
+driver
+driver.dSYM

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -2,3 +2,12 @@
 *.ll
 driver
 driver.dSYM
+ast.cpp
+bv.cpp
+data_layout.cpp
+driver.cpp
+llvm_lib.cpp
+parser.cpp
+pp.cpp
+simulate.cpp
+type_context.cpp

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,17 @@
 
-LEAN_HOME=$(HOME)/code/lean4
-LLVM_HOME=$(HOME)/build/llvm-8.0.0.src/
+LEAN_HOME=$(HOME)/opt/lean4
+LLVM_HOME=$(HOME)/opt/llvm-8.0.0
+
+LEAN:=$(LEAN_HOME)/bin/lean
+LEANC:=$(LEAN_HOME)/bin/leanc
+LEAN_INCLUDE:=$(LEAN_HOME)/include
+
+LLVM_INCLUDE:=$(LLVM_HOME)/include
+LLVM_LIB=$(LLVM_HOME)/lib
+
+#LEAN_HOME=$(HOME)/code/lean4
+#LLVM_HOME?=$(HOME)/build/llvm-8.0.0.src/
+
 CLANG=clang++
 
 SOURCES := ast.lean\
@@ -20,13 +31,13 @@ OBJS=$(SOURCES:.cpp=.o)
 all : driver
 
 driver : $(CPP) $(OLEAN) llvm_exports.cpp driver.cpp
-	$(LEAN_HOME)/bin/leanc -O1 -g -L$(LLVM_HOME)/build/lib -I$(LLVM_HOME)/include -I$(LLVM_HOME)/build/include -I$(LEAN_HOME)/src -I$(LEAN_HOME)/src/runtime -lLLVMCore -lLLVMSupport -lLLVMBinaryFormat -lLLVMDemangle -ltermcap -lLLVMBitReader -o "driver" llvm_exports.cpp $(CPP)
+	$(LEANC) -O1 -g -L$(LLVM_LIB) -I$(LLVM_INCLUDE) -I$(LEAN_INCLUDE) -lLLVMCore -lLLVMSupport -lLLVMBinaryFormat -lLLVMDemangle -ltermcap -lLLVMBitReader -o "driver" llvm_exports.cpp $(CPP)
 
 %.cpp:	%.lean %.olean
-	$(LEAN_HOME)/bin/lean -c $@ $<
+	$(LEAN) -c $@ $<
 
 %.olean: %.lean
-	$(LEAN_HOME)/bin/lean --make $<
+	$(LEAN) --make $<
 
 
 driver.olean : ast.olean bv.olean pp.olean llvm_lib.olean simulate.olean
@@ -37,9 +48,8 @@ data_layout.olean : ast.olean parser.olean
 simulate.olean : ast.olean bv.olean pp.olean type_context.olean
 
 clean:
-	- rm $(CPP)
-	- rm *.o
-	- rm *.olean
+	- rm -f $(CPP)
+	- rm -f *.olean
 
 
 .PHONY : clean all

--- a/src/ast.lean
+++ b/src/ast.lean
@@ -10,15 +10,14 @@ namespace llvm
 -- def float : Type 0 := sorry
 -- def double : Type 0 := sorry
 
-
-def strmap (a:Type) := @RBMap String a (λx y, decide (x < y))
+def strmap (a:Type) := @RBMap String a (fun x y => decide (x < y))
 def strmap_empty (a:Type) : strmap a := RBMap.empty
 
 -- Identifiers -----------------------------------------------------------------
 
 inductive ident
 | named  : String → ident
-| anon : ℕ → ident
+| anon : Nat → ident
 .
 
 namespace ident.
@@ -37,31 +36,31 @@ def lt : ident → ident → Prop
 
 instance : HasLess ident := ⟨lt⟩.
 
-instance decideEq : Π(x y:ident), Decidable (x = y)
-| (ident.named a) (ident.named b) := 
+instance decideEq : ∀(x y:ident), Decidable (x = y)
+| (ident.named a) (ident.named b) :=
     (match decEq a b with
-     | Decidable.isTrue p  := Decidable.isTrue (congrArg _ p)
-     | Decidable.isFalse p := Decidable.isFalse (λH, ident.noConfusion H p)
+     | Decidable.isTrue p  => Decidable.isTrue (congrArg _ p)
+     | Decidable.isFalse p => Decidable.isFalse (fun H => ident.noConfusion H p)
     )
 | (ident.anon a) (ident.anon b) :=
     (match decEq a b with
-     | Decidable.isTrue p  := Decidable.isTrue (congrArg _ p)
-     | Decidable.isFalse p := Decidable.isFalse (λH, ident.noConfusion H p)
+     | Decidable.isTrue p  => Decidable.isTrue (congrArg _ p)
+     | Decidable.isFalse p => Decidable.isFalse (fun H => ident.noConfusion H p)
     )
-| (ident.anon _) (ident.named _) := Decidable.isFalse (λH, ident.noConfusion H)
-| (ident.named _) (ident.anon _) := Decidable.isFalse (λH, ident.noConfusion H)
+| (ident.anon _) (ident.named _) := Decidable.isFalse (fun H => ident.noConfusion H)
+| (ident.named _) (ident.anon _) := Decidable.isFalse (fun H => ident.noConfusion H)
 
 
-instance decideLt : Π(x y:ident), Decidable (x < y)
-| (ident.named x) (ident.named y) := 
+instance decideLt : ∀(x y:ident), Decidable (x < y)
+| (ident.named x) (ident.named y) :=
   (match String.decLt x y with
-   | Decidable.isTrue p  := Decidable.isTrue p
-   | Decidable.isFalse p := Decidable.isFalse (λH, p H)
+   | Decidable.isTrue  p => Decidable.isTrue p
+   | Decidable.isFalse p => Decidable.isFalse p
    )
 | (ident.anon x) (ident.anon y) :=
   (match Nat.decLt x y with
-   | Decidable.isTrue p  := Decidable.isTrue p
-   | Decidable.isFalse p := Decidable.isFalse (λH, p H)
+   | Decidable.isTrue  p => Decidable.isTrue p
+   | Decidable.isFalse p => Decidable.isFalse p
    )
 | (ident.named _) (ident.anon _)  := Decidable.isTrue True.intro
 | (ident.anon _)  (ident.named _) := Decidable.isFalse False.elim
@@ -91,17 +90,17 @@ inductive endian
 -- The labels are mainly for documentation, taken from parseSpecifier
 inductive layout_spec
   | endianness : endian → layout_spec
-  | pointer_size  (address_space : ℕ)
-                  (size : ℕ)
-                  (abi_align : ℕ)
-                  (pref_align : ℕ)
-                  (index_size : Option ℕ) : layout_spec
-  | align_size    (align_type : align_type) (size : ℕ)
-                  (abi_align : ℕ) (pref_align : Option ℕ) : layout_spec
-  | native_int_size (legal_widths : List ℕ)     : layout_spec
-  | stack_align    : ℕ -> layout_spec
-  | function_address_space : ℕ -> layout_spec
-  | stack_alloca  : ℕ -> layout_spec
+  | pointer_size  (address_space : Nat)
+                  (size : Nat)
+                  (abi_align : Nat)
+                  (pref_align : Nat)
+                  (index_size : Option Nat) : layout_spec
+  | align_size    (align_type : align_type) (size : Nat)
+                  (abi_align : Nat) (pref_align : Option Nat) : layout_spec
+  | native_int_size (legal_widths : List Nat)     : layout_spec
+  | stack_align    : Nat -> layout_spec
+  | function_address_space : Nat -> layout_spec
+  | stack_alloca  : Nat -> layout_spec
   | mangling : mangling -> layout_spec
 .
 
@@ -118,7 +117,7 @@ inductive float_type
 inductive prim_type
   | label
   | void
-  | integer : ℕ -> prim_type
+  | integer : Nat -> prim_type
   | float_type : float_type -> prim_type
   | x86mmx
   | metadata
@@ -126,12 +125,12 @@ inductive prim_type
 inductive llvm_type
   | prim_type : prim_type -> llvm_type
   | alias : String -> llvm_type
-  | array : ℕ -> llvm_type -> llvm_type
+  | array : Nat -> llvm_type -> llvm_type
   | fun_ty : llvm_type -> List llvm_type -> Bool -> llvm_type
   | ptr_to : llvm_type -> llvm_type
   | struct : List llvm_type -> llvm_type
   | packed_struct : List llvm_type -> llvm_type
-  | vector : ℕ -> llvm_type -> llvm_type
+  | vector : Nat -> llvm_type -> llvm_type
   | opaque : llvm_type
 
 -- Top-level Type Aliases ------------------------------------------------------
@@ -146,24 +145,24 @@ structure symbol := (symbol : String)
 
 inductive block_label
   | named : String -> block_label
-  | anon : ℕ -> block_label
+  | anon : Nat -> block_label
 
 
 namespace block_label.
 
-instance decideEq : Π(x y:block_label), Decidable (x = y)
-| (block_label.named a) (block_label.named b) := 
+instance decideEq : ∀(x y:block_label), Decidable (x = y)
+| (block_label.named a) (block_label.named b) :=
     (match decEq a b with
-     | Decidable.isTrue p  := Decidable.isTrue (congrArg _ p)
-     | Decidable.isFalse p := Decidable.isFalse (λH, block_label.noConfusion H p)
+     | Decidable.isTrue p  => Decidable.isTrue (congrArg _ p)
+     | Decidable.isFalse p => Decidable.isFalse (fun H => block_label.noConfusion H p)
     )
 | (block_label.anon a) (block_label.anon b) :=
     (match decEq a b with
-     | Decidable.isTrue p  := Decidable.isTrue (congrArg _ p)
-     | Decidable.isFalse p := Decidable.isFalse (λH, block_label.noConfusion H p)
+     | Decidable.isTrue p  => Decidable.isTrue (congrArg _ p)
+     | Decidable.isFalse p => Decidable.isFalse (fun H => block_label.noConfusion H p)
     )
-| (block_label.anon _) (block_label.named _) := Decidable.isFalse (λH, block_label.noConfusion H)
-| (block_label.named _) (block_label.anon _) := Decidable.isFalse (λH, block_label.noConfusion H)
+| (block_label.anon _) (block_label.named _) := Decidable.isFalse (fun H => block_label.noConfusion H)
+| (block_label.named _) (block_label.anon _) := Decidable.isFalse (fun H => block_label.noConfusion H)
 .
 
 end block_label.
@@ -285,7 +284,7 @@ with value : Type
 
 with const_expr : Type
   | select : typed value -> typed value -> typed value -> const_expr
-  | gep : Bool -> Option ℕ -> llvm_type -> List (typed value) -> const_expr
+  | gep : Bool -> Option Nat -> llvm_type -> List (typed value) -> const_expr
   | conv : conv_op -> typed value -> llvm_type -> const_expr
   | arith : arith_op -> typed value -> value -> const_expr
   | fcmp : fcmp_op -> typed value -> typed value -> const_expr
@@ -296,15 +295,15 @@ with const_expr : Type
 with val_md : Type
   | string : String -> val_md
   | value : typed value -> val_md
-  | ref : ℕ -> val_md
+  | ref : Nat -> val_md
   | node : List (Option val_md) -> val_md
   | loc : debug_loc -> val_md
   | debug_info : val_md -- FIXME , just a placeholder for now
 
 with debug_loc : Type
   | debug_loc
-   ( line  : ℕ )
-   ( col   : ℕ )
+   ( line  : Nat )
+   ( col   : Nat )
    ( scope : val_md )
    ( IA    : Option val_md )
    : debug_loc
@@ -316,7 +315,7 @@ inductive instruction : Type
   | arith : arith_op -> typed value -> value -> instruction
   | bit : bit_op -> typed value -> value -> instruction
   | conv : conv_op -> typed value -> llvm_type -> instruction
-  | call : Π(tailcall : Bool), llvm_type -> value -> List (typed value) -> instruction
+  | call (tailcall : Bool) : llvm_type -> value -> List (typed value) -> instruction
   | alloca : llvm_type -> Option (typed value) -> Option Nat -> instruction
   | load : typed value -> Option atomic_ordering -> Option Nat /- align -/ -> instruction
   | store : typed value -> typed value -> Option Nat /- align -/ -> instruction
@@ -332,8 +331,8 @@ inductive instruction : Type
   | phi : llvm_type -> Array (value × block_label) -> instruction
   | gep (bounds : Bool) : typed value -> List (typed value) -> instruction
   | select : typed value -> typed value -> value -> instruction
-  | extract_value : typed value -> List ℕ -> instruction
-  | insert_value : typed value -> typed value -> List ℕ -> instruction
+  | extract_value : typed value -> List Nat -> instruction
+  | insert_value : typed value -> typed value -> List Nat -> instruction
   | extract_elt : typed value -> value -> instruction
   | insert_elt : typed value -> typed value -> value -> instruction
   | shuffle_vector : typed value -> value -> typed value -> instruction
@@ -345,7 +344,7 @@ inductive instruction : Type
   | unwind
   | va_arg : typed value -> llvm_type -> instruction
   | indirect_br : typed value -> List block_label -> instruction
-  | switch : typed value -> block_label -> List (ℕ × block_label) -> instruction
+  | switch : typed value -> block_label -> List (Nat × block_label) -> instruction
   | landing_pad : llvm_type -> Option (typed value) -> Bool -> List (clause × typed value) -> instruction
   | resume : typed value -> instruction
 
@@ -353,12 +352,12 @@ inductive instruction : Type
 
 structure named_md :=
   ( name   : String)
-  ( values : List ℕ)
+  ( values : List Nat)
 
 -- Unnamed Metadata ------------------------------------------------------------
 
 structure unnamed_md :=
-  ( index  : ℕ)
+  ( index  : Nat)
   ( values : val_md)
   ( distinct : Bool)
 
@@ -404,11 +403,11 @@ structure global :=
   ( attrs : global_attrs             )
   ( type  : llvm_type                )
   ( value : Option value            )
-  ( align : Option ℕ              )
+  ( align : Option Nat              )
   ( metadata : strmap val_md )
 
 inductive fun_attr
-   | align_stack : ℕ -> fun_attr
+   | align_stack : Nat -> fun_attr
    | alwaysinline
    | builtin
    | cold

--- a/src/bv.lean
+++ b/src/bv.lean
@@ -2,36 +2,37 @@ import init.data.nat
 import init.data.nat.div
 import init.data.nat.bitwise
 
-structure bv (w:ℕ) :=
-  ( to_nat : ℕ )
+structure bv (w : Nat) :=
+  ( to_nat : Nat )
   ( prop  : to_nat < 2^w )
 
 namespace bv.
-  def less {w:ℕ} (x y:bv w) := x.to_nat < y.to_nat.
-  instance bvHasLess {w:ℕ} : HasLess (bv w) := ⟨bv.less⟩.
-  instance decLt {w:ℕ} (x y:bv w) : Decidable (x < y) := Nat.decLt x.to_nat y.to_nat.
+  def less {w:Nat} (x y:bv w) := x.to_nat < y.to_nat.
+  instance bvHasLess {w:Nat} : HasLess (bv w) := ⟨bv.less⟩.
+  instance decLt {w:Nat} (x y:bv w) : Decidable (x < y) := Nat.decLt x.to_nat y.to_nat.
 end bv.
 
 namespace Nat
-local infix `▹`:50 := Eq.trans. 
+--local infix `▹`:50 := Eq.trans.
 
-def mod_eq (m:ℕ) (x y : ℕ) : Prop :=
-  ∃(nx ny:ℕ), x + m*nx = y + m*ny
+/-
+def mod_eq (m:Nat) (x y : Nat) : Prop :=
+  ∃(nx ny:Nat), x + m*nx = y + m*ny
 
-def mod_eq_symm (m:ℕ) (x y:ℕ) :
+def mod_eq_symm (m:Nat) (x y:Nat) :
   mod_eq m x y →
   mod_eq m y x :=
 
   λ⟨nx, ny, Hxy⟩, ⟨ny, nx, Eq.symm Hxy ⟩.
 
-def mod_eq_refl (m:ℕ) (x y:ℕ) :
+def mod_eq_refl (m:Nat) (x y:Nat) :
   x = y →
   mod_eq m x y :=
 
   λ H, ⟨ 0, 0, H ⟩.
 
 
-def mod_eq_trans (m:ℕ) (x y z:ℕ) :
+def mod_eq_trans (m:Nat) (x y z:Nat) :
   mod_eq m x y →
   mod_eq m y z →
   mod_eq m x z  :=
@@ -41,52 +42,52 @@ def mod_eq_trans (m:ℕ) (x y z:ℕ) :
        (congrArg _ (Nat.leftDistrib _ _ _) ▹ (Nat.addAssoc _ _ _).symm) ▹
        (congr (congrArg _ Hxy) rfl) ▹ Nat.addAssoc _ _ _ ▹
        Eq.symm (
-       (congrArg _ (Nat.leftDistrib _ _ _) ▹ congrArg _ (Nat.addComm _ _) ▹ (Nat.addAssoc _ _ _).symm) ▹ 
-       congr (congrArg _ Hyz.symm) rfl ▹ Nat.addAssoc _ _ _ ▹ 
+       (congrArg _ (Nat.leftDistrib _ _ _) ▹ congrArg _ (Nat.addComm _ _) ▹ (Nat.addAssoc _ _ _).symm) ▹
+       congr (congrArg _ Hyz.symm) rfl ▹ Nat.addAssoc _ _ _ ▹
        congrArg _ (Nat.addComm _ _))
     ⟩.
 
-def eq_le {x y:ℕ} (H:x = y) : x ≤ y :=
+def eq_le {x y:Nat} (H:x = y) : x ≤ y :=
   H ▸ Nat.leRefl x.
 
-def sub_cancel (x:ℕ) : ∀m, (x + m) - m = x :=
-  @Nat.rec (λm, (x+m) - m = x) rfl (λm (H:(x+m)-m = x), 
+def sub_cancel (x:Nat) : ∀m, (x + m) - m = x :=
+  @Nat.rec (λm, (x+m) - m = x) rfl (λm (H:(x+m)-m = x),
      have H' : (succ (x+m) - succ m) = (x+m) - m := Nat.succSubSuccEqSub (x+m) m,
      Eq.trans H' H).
 
-def sub_cancel2 : ∀(x m:ℕ), m ≤ x → (x-m) + m = x :=
-  @Nat.rec (λ x, ∀m, m ≤ x → (x-m) + m = x) 
-    (λ m, Nat.casesOn m (λ _, rfl) (λn H, False.elim (Nat.notLtZero _ H))) 
-    (λ x Hind m, Nat.casesOn m (λ _, rfl) (λ n H, 
+def sub_cancel2 : ∀(x m:Nat), m ≤ x → (x-m) + m = x :=
+  @Nat.rec (λ x, ∀m, m ≤ x → (x-m) + m = x)
+    (λ m, Nat.casesOn m (λ _, rfl) (λn H, False.elim (Nat.notLtZero _ H)))
+    (λ x Hind m, Nat.casesOn m (λ _, rfl) (λ n H,
       have Hnx : n ≤ x := leOfSuccLeSucc H,
       have Hsub : (x - n) + n = x := Hind _ Hnx,
       congrArg succ (congr (congrArg Nat.add (Nat.succSubSuccEqSub _ _)) rfl ▹ Hsub)
       ))
 .
 
-def euclidian_div (m x:ℕ) : x = x%m + m*(x/m) := 
+def euclidian_div (m x:Nat) : x = x%m + m*(x/m) :=
 
-  Nat.div.inductionOn x m 
-    (λ a b H1 H2, 
+  Nat.div.inductionOn x m
+    (λ a b H1 H2,
       have Hdiv  : a/b = (a-b)/b + 1 := Nat.divDef a b ▹ ifPos H1,
       have Hdiv' : b*(a/b) = b*((a-b)/b + 1) := congrArg _ Hdiv,
       have Hmod : a%b = (a-b)%b     := Nat.modDef a b ▹ ifPos H1,
       have Ha   : a = (a-b) + b     := (sub_cancel2 a b H1.right).symm,
-      Ha ▹ congr (congrArg _ H2) rfl ▹ Nat.addAssoc _ _ _ ▹ 
+      Ha ▹ congr (congrArg _ H2) rfl ▹ Nat.addAssoc _ _ _ ▹
       congr (congrArg _ Hmod.symm) Hdiv'.symm
     )
-    (λ a b H, 
+    (λ a b H,
      have Hdiv : a/b = 0 := Nat.divDef a b ▹ ifNeg H,
-     have Hdiv' : b*(a/b) = 0 := congrArg _ Hdiv ▹ rfl, 
+     have Hdiv' : b*(a/b) = 0 := congrArg _ Hdiv ▹ rfl,
      have Hmod  : a%b = a := Nat.modDef a b ▹ ifNeg H,
      Hmod.symm ▹ (Nat.addZero (a%b)).symm ▹ congrArg _ Hdiv'.symm)
 .
 
-def mod_eq_mod (m x:ℕ) : mod_eq m x (x%m) :=
+def mod_eq_mod (m x:Nat) : mod_eq m x (x%m) :=
   ⟨ 0, x/m, euclidian_div m x ⟩
 .
 
-def mod_reduce (m x:ℕ) : ∀n, (x + m*n) % m = x % m :=
+def mod_reduce (m x:Nat) : ∀n, (x + m*n) % m = x % m :=
 
   @Nat.rec (λn,(x + m*n) % m = x % m) rfl (λn H,
     have Hm : m ≤ x + (m*n + m) :=
@@ -100,18 +101,18 @@ def mod_reduce (m x:ℕ) : ∀n, (x + m*n) % m = x % m :=
 .
 
 
-def rearrange1 (a b c d : ℕ) :
-  (a+b)+(c+d) = a + c + (b + d) := 
+def rearrange1 (a b c d : Nat) :
+  (a+b)+(c+d) = a + c + (b + d) :=
 
   Nat.addAssoc a b (c+d) ▹
-  congr rfl 
-    ((Nat.addAssoc b c d).symm ▹ congr (congrArg _ (Nat.addComm b c)) rfl ▹ 
+  congr rfl
+    ((Nat.addAssoc b c d).symm ▹ congr (congrArg _ (Nat.addComm b c)) rfl ▹
      (Nat.addAssoc c b d)
     ) ▹
   (Nat.addAssoc a c (b+d)).symm
 .
 
-def mod_homomorphism_add (m:ℕ) (a b c d:ℕ) :
+def mod_homomorphism_add (m:Nat) (a b c d:Nat) :
   mod_eq m a c →
   mod_eq m b d →
   mod_eq m (a + b) (c + d) :=
@@ -119,16 +120,16 @@ def mod_homomorphism_add (m:ℕ) (a b c d:ℕ) :
  λ⟨ na, nc, Hac ⟩, λ⟨ nb, nd, Hbd ⟩,
    ⟨ na + nb, nc + nd ,
       have H1 : (a + m*na)+(b + m *nb) = (c + m*nc)+(d + m*nd) := congr (congrArg Nat.add Hac) Hbd,
-      have H2 : a + b + (m * na + m * nb) = c + d + (m*nc + m*nd) := 
+      have H2 : a + b + (m * na + m * nb) = c + d + (m*nc + m*nd) :=
         (rearrange1 a b (m*na) (m*nb)) ▹ H1 ▹ (rearrange1 c d (m*nc) (m*nd)).symm,
       (Nat.leftDistrib m nc nd).symm ▸ (Nat.leftDistrib m na nb).symm ▸ H2
    ⟩.
 
 
-def rearrange2 (a b c d m:ℕ) :
-  (a+m*b)*(c+m*d) = a*c + m*(a*d + c*b + b*d*m) := 
+def rearrange2 (a b c d m:Nat) :
+  (a+m*b)*(c+m*d) = a*c + m*(a*d + c*b + b*d*m) :=
 
-  have H1 : m * (a * d) = a * (m * d) := 
+  have H1 : m * (a * d) = a * (m * d) :=
      (Nat.mulAssoc _ _ _).symm ▹ congr (congrArg _ (Nat.mulComm _ _)) rfl ▹ Nat.mulAssoc _ _ _,
   have H2 : m * (c * b) = m * b * c :=
      congrArg _ (Nat.mulComm _ _) ▹ (Nat.mulAssoc _ _ _).symm,
@@ -146,18 +147,18 @@ def rearrange2 (a b c d m:ℕ) :
               congr (congrArg _ (Nat.leftDistrib _ _ _ ▹ congr (congrArg _ H1) H2)) H3))
    ).
 
-def mod_homomorphism_mul (m:ℕ) (a b c d:ℕ) :
+def mod_homomorphism_mul (m:Nat) (a b c d:Nat) :
   mod_eq m a c →
   mod_eq m b d →
   mod_eq m (a * b) (c * d) :=
 
  λ⟨ na, nc, Hac ⟩, λ⟨ nb, nd, Hbd ⟩,
-   ⟨ a*nb + b*na + na*nb*m, c*nd + d*nc + nc*nd*m, 
+   ⟨ a*nb + b*na + na*nb*m, c*nd + d*nc + nc*nd*m,
       have H1 : (a + m*na)*(b + m *nb) = (c + m*nc)*(d + m*nd) := congr (congrArg Nat.mul Hac) Hbd,
       (rearrange2 a na b nb m).symm ▹ H1 ▹ rearrange2 c nc d nd m
    ⟩.
 
-def mod_eq_eq (m:ℕ) (x y:ℕ) :
+def mod_eq_eq (m:Nat) (x y:Nat) :
   mod_eq m x y →
   x%m = y%m :=
 
@@ -165,31 +166,34 @@ def mod_eq_eq (m:ℕ) (x y:ℕ) :
    have Hxy' : (x + m * nx)%m = (y + m*ny)%m := congr (congrArg Nat.mod Hxy) rfl,
    mod_reduce m y ny ▸ mod_reduce m x nx ▸ Hxy'.
 
-def mod_eq_eq' (m:ℕ) (x y:ℕ) :
+def mod_eq_eq' (m:Nat) (x y:Nat) :
   x%m = y%m →
-  mod_eq m x y := 
+  mod_eq m x y :=
 
   λH,
 
   have x+y = y+x,
     from Nat.addComm x y,
-  have x+(x%m + m*(y/m)) = y + (x%m + m*(x/m)), 
+  have x+(x%m + m*(y/m)) = y + (x%m + m*(x/m)),
     from Nat.euclidian_div m x ▸ H.symm ▸ Nat.euclidian_div m y ▸ this,
   have x%m + (x+m*(y/m)) = x%m + (y + m*(x/m)),
-    from (Nat.addAssoc _ _ _).symm ▹ congr (congrArg _ (Nat.addComm _ _)) rfl ▹ Nat.addAssoc _ _ _ ▹ this ▹ 
+    from (Nat.addAssoc _ _ _).symm ▹ congr (congrArg _ (Nat.addComm _ _)) rfl ▹ Nat.addAssoc _ _ _ ▹ this ▹
          (Nat.addAssoc _ _ _).symm ▹ congr (congrArg _ (Nat.addComm _ _)) rfl ▹ Nat.addAssoc _ _ _,
   ⟨ y/m , x/m, Nat.addLeftCancel this⟩
 .
+-/
 
 end Nat
 
 namespace bv
-local infix `▹`:50 := Eq.trans. 
+/-
+local infix `▹`:50 := Eq.trans.
+-/
 
-protected def from_nat (w:ℕ) (val:ℕ) : bv w :=
+protected def from_nat (w:Nat) (val:Nat) : bv w :=
   ⟨val % 2^w, Nat.modLt val (Nat.posPowOfPos w rfl) ⟩.
 
-protected def from_int (w:ℕ) : Int → bv w
+protected def from_int (w:Nat) : Int → bv w
 | (Int.ofNat n)   := bv.from_nat w n
 | (Int.negSucc n) := let n' := (n % 2^(w-1))+1 in bv.from_nat w (2^w - n')
 .
@@ -201,47 +205,49 @@ protected def to_int {w} (x:bv w) : Int :=
     Int.ofNat x.to_nat - Int.ofNat (2^w)
 .
 
-def bv_ext {w:ℕ} : Π{x y:bv w}, x.to_nat = y.to_nat → x = y
+/-
+def bv_ext {w:Nat} : Π{x y:bv w}, x.to_nat = y.to_nat → x = y
 | ⟨xv, xp⟩ ⟨_,yp⟩ rfl := rfl
 .
+-/
 
-def add {w:ℕ} (x y : bv w) : bv w :=
+def add {w:Nat} (x y : bv w) : bv w :=
   bv.from_nat w (x.to_nat + y.to_nat).
 
-def sub {w:ℕ} (x y : bv w) : bv w :=
+def sub {w:Nat} (x y : bv w) : bv w :=
   bv.from_nat w (x.to_nat + (2^w - y.to_nat)).
 
-def negate {w:ℕ} (x : bv w) : bv w :=
+def negate {w:Nat} (x : bv w) : bv w :=
   bv.from_nat w (2^w - x.to_nat).
 
-def mul {w:ℕ} (x y : bv w) : bv w :=
+def mul {w:Nat} (x y : bv w) : bv w :=
   bv.from_nat w (x.to_nat * y.to_nat).
 
-def bitwise_and {w:ℕ} (x y: bv w) : bv w :=
+def bitwise_and {w:Nat} (x y: bv w) : bv w :=
   bv.from_nat w (Nat.land x.to_nat y.to_nat).
 
-def bitwise_or {w:ℕ} (x y: bv w) : bv w :=
+def bitwise_or {w:Nat} (x y: bv w) : bv w :=
   bv.from_nat w (Nat.lor x.to_nat y.to_nat).
 
 -- TODO, define/bind to efficent versions of these bitwise operations
-def bitwise_xor {w:ℕ} (x y:bv w) : bv w :=
+def bitwise_xor {w:Nat} (x y:bv w) : bv w :=
   bv.from_nat w (Nat.bitwise xor x.to_nat y.to_nat).
 
-def shl {w:ℕ} (x y: bv w) : bv w :=
+def shl {w:Nat} (x y: bv w) : bv w :=
   bv.from_nat w (x.to_nat * (2 ^ y.to_nat)).
 
-def lshr {w:ℕ} (x y:bv w) : bv w :=
+def lshr {w:Nat} (x y:bv w) : bv w :=
   bv.from_nat w (x.to_nat / (2 ^ y.to_nat)).
 
-def ashr {w:ℕ} (x y:bv w) : bv w :=
+def ashr {w:Nat} (x y:bv w) : bv w :=
   bv.from_int w (x.to_int / Int.ofNat (2 ^ y.to_nat)).
 
 
-
-def bv_mod_eq (w:ℕ) (x y:ℕ) : Nat.mod_eq (2^w) x y → bv.from_nat w x = bv.from_nat w y := 
+/-
+def bv_mod_eq (w:Nat) (x y:Nat) : Nat.mod_eq (2^w) x y → bv.from_nat w x = bv.from_nat w y :=
   bv_ext ∘ Nat.mod_eq_eq (2^w) x y.
 
-def add_assoc (w:ℕ) (x y z:bv w) :
+def add_assoc (w:Nat) (x y z:bv w) :
   bv.add x (bv.add y z) = bv.add (bv.add x y) z :=
 
   have H1 : Nat.mod_eq (2^w) (x.to_nat + (bv.add y z).to_nat) (x.to_nat + (y.to_nat + z.to_nat)) :=
@@ -249,26 +255,26 @@ def add_assoc (w:ℕ) (x y z:bv w) :
   have H2 : Nat.mod_eq (2^w) ((bv.add x y).to_nat + z.to_nat) ((x.to_nat + y.to_nat) + z.to_nat) :=
     Nat.mod_homomorphism_add (2^w) _ _ _ _ (Nat.mod_eq_symm _ _ _ (Nat.mod_eq_mod _ _)) (Nat.mod_eq_refl _ _ _ rfl),
 
-  bv_mod_eq w _ _ 
-    (Nat.mod_eq_trans _ _ _ _ 
-      (Nat.mod_eq_trans _ _ _ _ H1 
+  bv_mod_eq w _ _
+    (Nat.mod_eq_trans _ _ _ _
+      (Nat.mod_eq_trans _ _ _ _ H1
       (Nat.mod_eq_refl _ _ _ (Nat.addAssoc _ _ _).symm)) (Nat.mod_eq_symm _ _ _ H2))
 .
 
-def sub_add_negate (w:ℕ) (x y:bv w) :
+def sub_add_negate (w:Nat) (x y:bv w) :
   bv.add x (bv.negate y) = bv.sub x y :=
 
-  bv_mod_eq w _ _ 
+  bv_mod_eq w _ _
       (Nat.mod_homomorphism_add _ _ _ _ _
-        (Nat.mod_eq_refl _ _ _ rfl) 
+        (Nat.mod_eq_refl _ _ _ rfl)
         (Nat.mod_eq_symm _ _ _ (Nat.mod_eq_mod _ _))).
 
-def negate_inverse (w:ℕ) (x:bv w) :
+def negate_inverse (w:Nat) (x:bv w) :
   bv.add x (bv.negate x) = bv.from_nat w 0 :=
 
   have H1 : Nat.mod_eq (2^w) (x.to_nat + (2^w - x.to_nat)%2^w) (x.to_nat + (2^w - x.to_nat)) :=
     Nat.mod_homomorphism_add _ _ _ _ _ (Nat.mod_eq_refl _ _ _ rfl) (Nat.mod_eq_symm _ _ _ (Nat.mod_eq_mod _ _)),
-  have H2 : Nat.mod_eq (2^w) (x.to_nat + (2^w - x.to_nat)) (2^w) := Nat.mod_eq_refl _ _ _ 
+  have H2 : Nat.mod_eq (2^w) (x.to_nat + (2^w - x.to_nat)) (2^w) := Nat.mod_eq_refl _ _ _
     ( Nat.addComm _ _ ▹ Nat.sub_cancel2 _ _ (Nat.leOfLt x.prop)),
   have H3 : Nat.mod_eq (2^w) (2^w) 0 :=
     ⟨ 0, 1, (Nat.zeroAdd (2^w)).symm ▹ congrArg _ (Nat.mulOne _).symm⟩,
@@ -278,5 +284,6 @@ def negate_inverse (w:ℕ) (x:bv w) :
   bv_mod_eq w _ _ H4.
 .
 
+-/
 
 end bv.

--- a/src/data_layout.lean
+++ b/src/data_layout.lean
@@ -4,20 +4,20 @@ import .parser
 
 namespace llvm.parse.
 
-def pointer_spec : parse llvm.layout_spec := 
+def pointer_spec : parse llvm.layout_spec :=
   parse.describe "pointer spec spec" $
-  do addrSpace <- parse.opt 0 parse.nat,
-     sz   <- parse.text ":" *> parse.nat,
-     abi  <- parse.text ":" *> parse.nat,
-     pref <- parse.text ":" *> parse.nat,
-     idx  <- parse.opt' (parse.text ":" *> parse.nat),
+  do addrSpace <- parse.opt 0 parse.nat;
+     sz   <- parse.text ":" *> parse.nat;
+     abi  <- parse.text ":" *> parse.nat;
+     pref <- parse.text ":" *> parse.nat;
+     idx  <- parse.opt' (parse.text ":" *> parse.nat);
      pure (llvm.layout_spec.pointer_size addrSpace sz abi pref idx).
 
-def size_spec (t:llvm.align_type) : parse llvm.layout_spec := 
+def size_spec (t:llvm.align_type) : parse llvm.layout_spec :=
   parse.describe "size spec" $
-  do sz   <- parse.nat,
-     abi  <- parse.text ":" *> parse.nat,
-     pref <- parse.opt' (parse.text ":" *> parse.nat),
+  do sz   <- parse.nat;
+     abi  <- parse.text ":" *> parse.nat;
+     pref <- parse.opt' (parse.text ":" *> parse.nat);
      pure (llvm.layout_spec.align_size t sz abi pref).
 
 def mangling_spec : parse llvm.mangling :=
@@ -60,6 +60,6 @@ structure data_layout :=
   ( int_layout : endian )
 .
 
-  
+
 
 end llvm.

--- a/src/driver.lean
+++ b/src/driver.lean
@@ -10,11 +10,11 @@ open llvm.
 
 def main (xs : List String) : IO UInt32 := do
 
-  ctx ← newLLVMContext,
-  mb ← newMemoryBufferFromFile xs.head,
-  m ← parseBitcodeFile mb ctx >>= extractModule,
+  ctx ← newLLVMContext;
+  mb ← newMemoryBufferFromFile xs.head;
+  m ← parseBitcodeFile mb ctx >>= extractModule;
 
-  IO.println (pp.render (pp_module m)),
+  IO.println (pp.render (pp_module m));
 
   let res :=
      runFunc (symbol.mk "fib")
@@ -22,9 +22,8 @@ def main (xs : List String) : IO UInt32 := do
              ]
              (state.mk RBMap.empty m) in
   match res with
-  | (Sum.inl err) := throw err
-  | (Sum.inr (runtime_value.int _ x, _)) :=
-       do IO.println ("0x" ++ (Nat.toDigits 16 x.to_nat).asString),
+  | (Sum.inl err) => throw err
+  | (Sum.inr (runtime_value.int _ x, _)) =>
+       do IO.println ("0x" ++ (Nat.toDigits 16 x.to_nat).asString);
           pure 0
-  | _ := pure 0
-
+  | _ => pure 0

--- a/src/llvm_exports.cpp
+++ b/src/llvm_exports.cpp
@@ -5,9 +5,9 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Bitcode/BitcodeReader.h>
 
-#include "apply.h"
-#include "mpz.h"
-#include "object.h"
+#include "runtime/apply.h"
+#include "runtime/mpz.h"
+#include "runtime/object.h"
 #include <iostream>
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/llvm_lib.lean
+++ b/src/llvm_lib.lean
@@ -45,7 +45,7 @@ constant LLVMConstant := Unit
 
 inductive value_decomposition
 | unknown_value  : value_decomposition
-| argument_value : ℕ -> value_decomposition
+| argument_value : Nat -> value_decomposition
 | instruction_value : Instruction -> value_decomposition
 | constant_value : LLVMConstant -> value_decomposition
 .
@@ -95,10 +95,10 @@ def getBasicBlockArray : @& LLVMFunction -> IO (Array BasicBlock) := default _
 def getBBName : @& BasicBlock -> IO (Option String) := default _
 
 @[extern 2 cpp "lean_llvm::getTypeTag"]
-def getTypeTag : @& LLVMType -> IO ℕ := default _
+def getTypeTag : @& LLVMType -> IO Nat := default _
 
 @[extern 2 cpp "lean_llvm::getIntegerTypeWidth"]
-def getIntegerTypeWidth : @& LLVMType -> IO ℕ := default _
+def getIntegerTypeWidth : @& LLVMType -> IO Nat := default _
 
 @[extern 2 cpp "lean_llvm::getPointerElementType"]
 def getPointerElementType : @& LLVMType -> IO (Option LLVMType) := default _
@@ -119,7 +119,7 @@ def getInstructionName : @& Instruction -> IO (Option String) := default _
 def getInstructionType : @& Instruction -> IO LLVMType := default _
 
 @[extern 2 cpp "lean_llvm::getInstructionOpcode"]
-def getInstructionOpcode : @& Instruction -> IO ℕ := default _
+def getInstructionOpcode : @& Instruction -> IO Nat := default _
 
 @[extern 2 cpp "lean_llvm::getInstructionReturnValue"]
 def getInstructionReturnValue : @& Instruction -> IO (Option LLVMValue) := default _
@@ -143,14 +143,14 @@ def isExact : @& Instruction -> IO Bool := default _
 def decomposeValue : @& LLVMValue -> IO value_decomposition := default _
 
 @[extern 2 cpp "lean_llvm::getCmpInstData"]
-def getCmpInstData : @& Instruction -> IO (Option (ℕ × (LLVMValue × LLVMValue))) := default _
+def getCmpInstData : @& Instruction -> IO (Option (Nat × (LLVMValue × LLVMValue))) := default _
 
 @[extern 2 cpp "lean_llvm::getSelectInstData"]
 def getSelectInstData : @& Instruction -> IO (Option (LLVMValue × (LLVMValue × LLVMValue))) := default _
 
 -- return bitwidth and value
 @[extern 2 cpp "lean_llvm::getConstIntData"]
-def getConstIntData : @& LLVMConstant -> IO (Option (ℕ × ℕ)) := default _
+def getConstIntData : @& LLVMConstant -> IO (Option (Nat × Nat)) := default _
 
 @[extern 2 cpp "lean_llvm::getBranchInstData"]
 def getBranchInstData : @& Instruction -> IO (Option branch_decomposition) := default _
@@ -159,53 +159,52 @@ def getBranchInstData : @& Instruction -> IO (Option branch_decomposition) := de
 def getPhiData : @& Instruction -> IO (Option (Array (LLVMValue × BasicBlock))) := default _
 
 @[extern 2 cpp "lean_llvm::getCastInstData"]
-def getCastInstData : @& Instruction -> IO (Option (ℕ × LLVMValue)) := default _
+def getCastInstData : @& Instruction -> IO (Option (Nat × LLVMValue)) := default _
 
 @[extern 2 cpp "lean_llvm::getAllocaData"]
-def getAllocaData : @& Instruction -> IO (Option (LLVMType × (Option LLVMValue × Option ℕ))) := default _
+def getAllocaData : @& Instruction -> IO (Option (LLVMType × (Option LLVMValue × Option Nat))) := default _
 
 @[extern 2 cpp "lean_llvm::getStoreData"]
-def getStoreData : @& Instruction -> IO (Option (LLVMValue × (LLVMValue × Option ℕ))) := default _
+def getStoreData : @& Instruction -> IO (Option (LLVMValue × (LLVMValue × Option Nat))) := default _
 
 @[extern 2 cpp "lean_llvm::getLoadData"]
-def getLoadData : @& Instruction -> IO (Option (LLVMValue × Option ℕ)) := default _
+def getLoadData : @& Instruction -> IO (Option (LLVMValue × Option Nat)) := default _
 
 namespace llvm.
 
 def typeIsVoid (tp : LLVMType) : IO Bool :=
-  do id <-getTypeTag tp,
+  do id <- getTypeTag tp;
      match id with
-     | 0 := pure true
-     | _ := pure false
-.
+     | 0 => pure true
+     | _ => pure false
 
 partial def extractType : LLVMType → IO llvm_type
 | tp :=
-  do id <- getTypeTag tp,
+  do id <- getTypeTag tp;
      match id with
-     | 0 := pure (llvm_type.prim_type prim_type.void)
-     | 1 := pure (llvm_type.prim_type (prim_type.float_type float_type.half))
-     | 2 := pure (llvm_type.prim_type (prim_type.float_type float_type.float))
-     | 3 := pure (llvm_type.prim_type (prim_type.float_type float_type.double))
-     | 4 := pure (llvm_type.prim_type (prim_type.float_type float_type.x86_fp80))
-     | 5 := pure (llvm_type.prim_type (prim_type.float_type float_type.fp128))
-     | 6 := pure (llvm_type.prim_type (prim_type.float_type float_type.ppc_fp128))
-     | 7 := pure (llvm_type.prim_type prim_type.label)
-     | 8 := pure (llvm_type.prim_type prim_type.metadata)
-     | 9 := pure (llvm_type.prim_type prim_type.x86mmx)
-     | 10 := pure (llvm_type.opaque)
-     | 11 := (do n <- getIntegerTypeWidth tp,
+     | 0 => pure (llvm_type.prim_type prim_type.void)
+     | 1 => pure (llvm_type.prim_type (prim_type.float_type float_type.half))
+     | 2 => pure (llvm_type.prim_type (prim_type.float_type float_type.float))
+     | 3 => pure (llvm_type.prim_type (prim_type.float_type float_type.double))
+     | 4 => pure (llvm_type.prim_type (prim_type.float_type float_type.x86_fp80))
+     | 5 => pure (llvm_type.prim_type (prim_type.float_type float_type.fp128))
+     | 6 => pure (llvm_type.prim_type (prim_type.float_type float_type.ppc_fp128))
+     | 7 => pure (llvm_type.prim_type prim_type.label)
+     | 8 => pure (llvm_type.prim_type prim_type.metadata)
+     | 9 => pure (llvm_type.prim_type prim_type.x86mmx)
+     | 10 => pure (llvm_type.opaque)
+     | 11 => (do n <- getIntegerTypeWidth tp;
                  pure (llvm_type.prim_type (prim_type.integer n)))
-     | 12 := pure llvm_type.opaque -- functions
-     | 13 := pure llvm_type.opaque -- structures
-     | 14 := pure llvm_type.opaque -- arrays
-     | 15 := (do eltp <- getPointerElementType tp,
+     | 12 => pure llvm_type.opaque -- functions
+     | 13 => pure llvm_type.opaque -- structures
+     | 14 => pure llvm_type.opaque -- arrays
+     | 15 => (do eltp <- getPointerElementType tp;
                  match eltp with
-                 | none := throw (IO.userError "expected pointer type!")
-                 | (some x) := llvm_type.ptr_to <$> extractType x
+                 | none => throw (IO.userError "expected pointer type!")
+                 | (some x) => llvm_type.ptr_to <$> extractType x
              )
-     | 16 := pure llvm_type.opaque -- vectors
-     | _  := pure llvm_type.opaque -- other...
+     | 16 => pure llvm_type.opaque -- vectors
+     | _  => pure llvm_type.opaque -- other...
 .
 
 
@@ -221,332 +220,327 @@ structure value_context :=
   (imap : instrMap)
   (bmap : bbMap).
 
-def extractArgs (fn : LLVMFunction) : IO (ℕ × Array (typed ident)) :=
-  do rawargs <- getFunctionArgs fn,
-     Array.miterate rawargs (0, Array.empty) (λ_ a b,
-       let (mnm, rawtp) := a,
-           (counter, args) := b in
-       do tp <- extractType rawtp,
-          match mnm with
-          | none      := pure (counter+1, Array.push args (typed.mk tp (ident.anon counter)))
-          | (some nm) := pure (counter,   Array.push args (typed.mk tp (ident.named nm)))
+def extractArgs (fn : LLVMFunction) : IO (Nat × Array (typed ident)) :=
+  do rawargs <- getFunctionArgs fn;
+     Array.miterate rawargs (0, Array.empty) (λ _ a b => do
+       let (mnm, rawtp) := a;
+       let (counter, args) := b;
+       tp <- extractType rawtp;
+       match mnm with
+       | none      => pure (counter+1, Array.push args (typed.mk tp (ident.anon counter)))
+       | (some nm) => pure (counter,   Array.push args (typed.mk tp (ident.named nm)))
      )
 .
 
-def extractBBLabel (bb:BasicBlock) (c:ℕ) : IO (ℕ × block_label) :=
-  do nm <- getBBName bb,
+def extractBBLabel (bb:BasicBlock) (c:Nat) : IO (Nat × block_label) :=
+  do nm <- getBBName bb;
      match nm with
-     | none      := pure (c+1, block_label.anon c)
-     | (some nm) := pure (c  , block_label.named nm).
+     | none      => pure (c+1, block_label.anon c)
+     | (some nm) => pure (c  , block_label.named nm).
 
-def computeInstructionNumbering (rawbb:BasicBlock) (c0:ℕ) (imap0:instrMap) : IO (ℕ × instrMap) :=
-  do instrarr <- getInstructionArray rawbb,
+def computeInstructionNumbering (rawbb:BasicBlock) (c0:Nat) (imap0:instrMap) : IO (Nat × instrMap) :=
+  do instrarr <- getInstructionArray rawbb;
      Array.miterate instrarr (c0, imap0)
-       (λ _ rawi st,
+       (λ _ rawi st =>
          let (c,imap) := st in
-         do tp <- getInstructionType rawi,
-            isv <- typeIsVoid tp,
-            if isv then pure (c,imap) else
-            do mnm <- getInstructionName rawi,
-               match mnm with
-               | (some nm) := pure (c, RBMap.insert imap rawi (ident.named nm))
-               | none      := pure (c+1, RBMap.insert imap rawi (ident.anon c))
-       ).
+         do tp <- getInstructionType rawi;
+            isv <- typeIsVoid tp;
+            if isv then
+              pure (c,imap)
+            else
+              do mnm <- getInstructionName rawi;
+                 match mnm with
+                 | (some nm) => pure (c, RBMap.insert imap rawi (ident.named nm))
+                 | none      => pure (c+1, RBMap.insert imap rawi (ident.anon c))
+       )
 
-def computeNumberings (c0:ℕ) (fn:LLVMFunction) : IO (bbMap × instrMap) :=
-  do bbarr <- getBasicBlockArray fn,
+def computeNumberings (c0:Nat) (fn:LLVMFunction) : IO (bbMap × instrMap) :=
+  do bbarr <- getBasicBlockArray fn;
      (_,finalbmap, finalimap) <-
        Array.miterate bbarr (c0, (RBMap.empty : bbMap), (RBMap.empty : instrMap))
-         (λ_ rawbb st,
+         (λ_ rawbb st =>
             let (c, bmap, imap) := st in
-            do (c', blab) <- extractBBLabel rawbb c,
-               bmap' <- pure (RBMap.insert bmap rawbb blab),
-               (c'', imap') <- computeInstructionNumbering rawbb c' imap,
+            do (c', blab) <- extractBBLabel rawbb c;
+               bmap' <- pure (RBMap.insert bmap rawbb blab);
+               (c'', imap') <- computeInstructionNumbering rawbb c' imap;
                pure (c'',bmap',imap')
-         ),
+         );
      pure (finalbmap, finalimap).
 
 def extractConstant (rawc:LLVMConstant) : IO value :=
-  do d <- getConstIntData rawc,
+  do d <- getConstIntData rawc;
      (match d with
-      | (some (_w, v)) := pure (value.integer (Int.ofNat v))
-      | none := throw (IO.userError "unknown constant value"))
+      | (some (_w, v)) => pure (value.integer (Int.ofNat v))
+      | none => throw (IO.userError "unknown constant value"))
 
 def extractValue (ctx:value_context) (rawv:LLVMValue) : IO value :=
-  do decmp <- decomposeValue rawv,
+  do decmp <- decomposeValue rawv;
      match decmp with
-     | (value_decomposition.argument_value n) :=
+     | (value_decomposition.argument_value n) =>
        (match Array.getOpt ctx.fun_args n with
-        | none := throw (IO.userError "invalid argument value")
-        | (some i) := pure (value.ident i.value))
-
-     | (value_decomposition.instruction_value i) :=
+        | none => throw (IO.userError "invalid argument value")
+        | (some i) => pure (value.ident i.value))
+     | (value_decomposition.instruction_value i) =>
        (match RBMap.find ctx.imap i with
-        | none := throw (IO.userError "invalid instruction value")
-        | (some i) := pure (value.ident i)
+        | none => throw (IO.userError "invalid instruction value")
+        | (some i) => pure (value.ident i)
        )
 
-     | (value_decomposition.constant_value c) := extractConstant c
+     | (value_decomposition.constant_value c) => extractConstant c
 
-     | _ := throw (IO.userError "unknown value")
+     | _ => throw (IO.userError "unknown value")
 .
 
 def extractBlockLabel (ctx:value_context) (bb:BasicBlock) : IO block_label :=
   match RBMap.find ctx.bmap bb with
-  | none := throw (IO.userError "unknown basic block")
-  | (some lab) := pure lab.
-
+  | none => throw (IO.userError "unknown basic block")
+  | (some lab) => pure lab.
 
 def extractTypedValue (ctx:value_context) (rawv:LLVMValue) : IO (typed value) :=
-  do tp <- getValueType rawv >>= extractType,
-     v  <- extractValue ctx rawv,
+  do tp <- getValueType rawv >>= extractType;
+     v  <- extractValue ctx rawv;
      pure (typed.mk tp v)
  .
-
 def extractBinaryOp (rawInstr:Instruction) (ctx:value_context) (f:typed value → value → instruction) : IO instruction :=
-  getBinaryOperatorValues rawInstr >>= λx,
+  getBinaryOperatorValues rawInstr >>= λx =>
   match x with
-  | none := throw (IO.userError "expected binary operation")
-  | (some (o1,o2)) :=
-     do v1 <- extractTypedValue ctx o1,
-        v2 <- extractTypedValue ctx o2,
+  | none => throw (IO.userError "expected binary operation")
+  | (some (o1,o2)) =>
+     do v1 <- extractTypedValue ctx o1;
+        v2 <- extractTypedValue ctx o2;
         pure (f v1 v2.value)
 .
 
 def extractCastOp (rawinstr:Instruction) (ctx:value_context) (f:typed value → llvm_type → instruction) : IO instruction :=
-  getCastInstData rawinstr >>= λx,
+  getCastInstData rawinstr >>= λx =>
   match x with
-  | none := throw (IO.userError "expected conversion instruction")
-  | (some (_op, v)) :=
-      do tv <- extractTypedValue ctx v,
-         outty <- getInstructionType rawinstr >>= extractType,
+  | none => throw (IO.userError "expected conversion instruction")
+  | (some (_op, v)) =>
+      do tv <- extractTypedValue ctx v;
+         outty <- getInstructionType rawinstr >>= extractType;
          pure (f tv outty)
 
 -- C.F. llvm/InstrTypes.h, enum Predicate
-def extractICmpOp (n:ℕ) : IO icmp_op :=
+def extractICmpOp (n:Nat) : IO icmp_op :=
   match n with
-  | 32 := pure icmp_op.ieq
-  | 33 := pure icmp_op.ine
-  | 34 := pure icmp_op.iugt
-  | 35 := pure icmp_op.iuge
-  | 36 := pure icmp_op.iult
-  | 37 := pure icmp_op.iule
-  | 38 := pure icmp_op.isgt
-  | 39 := pure icmp_op.isge
-  | 40 := pure icmp_op.islt
-  | 41 := pure icmp_op.isle
-  | _  := throw (IO.userError ("unexpected icmp operation: " ++ (Nat.toDigits 10 n).asString))
+  | 32 => pure icmp_op.ieq
+  | 33 => pure icmp_op.ine
+  | 34 => pure icmp_op.iugt
+  | 35 => pure icmp_op.iuge
+  | 36 => pure icmp_op.iult
+  | 37 => pure icmp_op.iule
+  | 38 => pure icmp_op.isgt
+  | 39 => pure icmp_op.isge
+  | 40 => pure icmp_op.islt
+  | 41 => pure icmp_op.isle
+  | _  => throw (IO.userError ("unexpected icmp operation: " ++ (Nat.toDigits 10 n).asString))
 .
 
 def extractInstruction (rawinstr:Instruction) (ctx:value_context) : IO instruction :=
-  do op <- getInstructionOpcode rawinstr,
-     tp <- getInstructionType rawinstr >>= extractType,
+  do op <- getInstructionOpcode rawinstr;
+     tp <- getInstructionType rawinstr >>= extractType;
      match op with
      -- == terminators ==
      -- return
-     | 1 := do mv <- getInstructionReturnValue rawinstr,
-               (match mv with
-                | none := pure instruction.ret_void
-                | (some v) :=
-                  do tyv <- extractTypedValue ctx v,
+     | 1 => do mv <- getInstructionReturnValue rawinstr;
+               match mv with
+               | none => pure instruction.ret_void
+               | (some v) =>
+                  do tyv <- extractTypedValue ctx v;
                      pure (instruction.ret tyv)
-               )
 
      -- br
-     | 2 :=
-        do d <- getBranchInstData rawinstr,
-           (match d with
-            | none := throw (IO.userError "expected branch instruction")
-            | (some (branch_decomposition.unconditional b)) :=
-                instruction.jump <$> extractBlockLabel ctx b
-            | (some (branch_decomposition.conditional c t f)) :=
-                do cv <- extractTypedValue ctx c,
-                   tl <- extractBlockLabel ctx t,
-                   fl <- extractBlockLabel ctx f,
-                   pure (instruction.br cv tl fl)
-            )
+     | 2 =>
+        do d <- getBranchInstData rawinstr;
+           match d with
+           | none => throw (IO.userError "expected branch instruction")
+           | (some (branch_decomposition.unconditional b)) =>
+               instruction.jump <$> extractBlockLabel ctx b
+           | (some (branch_decomposition.conditional c t f)) =>
+               do cv <- extractTypedValue ctx c;
+                  tl <- extractBlockLabel ctx t;
+                  fl <- extractBlockLabel ctx f;
+                  pure (instruction.br cv tl fl)
 
      -- unreachable
-     | 7 := pure instruction.unreachable
+     | 7 => pure instruction.unreachable
 
      -- == binary operators ==
      -- add
-     | 12 :=
-        do uov <- hasNoUnsignedWrap rawinstr,
-           sov <- hasNoSignedWrap rawinstr,
+     | 12 =>
+        do uov <- hasNoUnsignedWrap rawinstr;
+           sov <- hasNoSignedWrap rawinstr;
            extractBinaryOp rawinstr ctx (instruction.arith (arith_op.add uov sov))
      -- fadd
-     | 13 := extractBinaryOp rawinstr ctx (instruction.arith arith_op.fadd)
+     | 13 => extractBinaryOp rawinstr ctx (instruction.arith arith_op.fadd)
      -- sub
-     | 14 :=
-        do uov <- hasNoUnsignedWrap rawinstr,
-           sov <- hasNoSignedWrap rawinstr,
+     | 14 =>
+        do uov <- hasNoUnsignedWrap rawinstr;
+           sov <- hasNoSignedWrap rawinstr;
            extractBinaryOp rawinstr ctx (instruction.arith (arith_op.sub uov sov))
      -- fsub
-     | 15 := extractBinaryOp rawinstr ctx (instruction.arith arith_op.fsub)
+     | 15 => extractBinaryOp rawinstr ctx (instruction.arith arith_op.fsub)
      -- mul
-     | 16 :=
-        do uov <- hasNoUnsignedWrap rawinstr,
-           sov <- hasNoSignedWrap rawinstr,
+     | 16 =>
+        do uov <- hasNoUnsignedWrap rawinstr;
+           sov <- hasNoSignedWrap rawinstr;
            extractBinaryOp rawinstr ctx (instruction.arith (arith_op.mul uov sov))
      -- fmul
-     | 17 := extractBinaryOp rawinstr ctx (instruction.arith arith_op.fmul)
+     | 17 => extractBinaryOp rawinstr ctx (instruction.arith arith_op.fmul)
      -- udiv
-     | 18 :=
-        do ex <- isExact rawinstr,
+     | 18 =>
+        do ex <- isExact rawinstr;
            extractBinaryOp rawinstr ctx (instruction.arith (arith_op.udiv ex))
      -- sdiv
-     | 19 :=
-        do ex <- isExact rawinstr,
+     | 19 =>
+        do ex <- isExact rawinstr;
            extractBinaryOp rawinstr ctx (instruction.arith (arith_op.sdiv ex))
      -- fdiv
-     | 20 := extractBinaryOp rawinstr ctx (instruction.arith arith_op.fdiv)
+     | 20 => extractBinaryOp rawinstr ctx (instruction.arith arith_op.fdiv)
      -- urem
-     | 21 := extractBinaryOp rawinstr ctx (instruction.arith arith_op.urem)
+     | 21 => extractBinaryOp rawinstr ctx (instruction.arith arith_op.urem)
      -- srem
-     | 22 := extractBinaryOp rawinstr ctx (instruction.arith arith_op.srem)
+     | 22 => extractBinaryOp rawinstr ctx (instruction.arith arith_op.srem)
      -- frem
-     | 23 := extractBinaryOp rawinstr ctx (instruction.arith arith_op.frem)
+     | 23 => extractBinaryOp rawinstr ctx (instruction.arith arith_op.frem)
 
      -- shl
-     | 24 :=
-         do uov <- hasNoUnsignedWrap rawinstr,
-            sov <- hasNoSignedWrap rawinstr,
+     | 24 =>
+         do uov <- hasNoUnsignedWrap rawinstr;
+            sov <- hasNoSignedWrap rawinstr;
             extractBinaryOp rawinstr ctx (instruction.bit (bit_op.shl uov sov))
      -- lshr
-     | 25 :=
-         do ex <- isExact rawinstr,
+     | 25 =>
+         do ex <- isExact rawinstr;
             extractBinaryOp rawinstr ctx (instruction.bit (bit_op.lshr ex))
      -- ashr
-     | 26 :=
-         do ex <- isExact rawinstr,
+     | 26 =>
+         do ex <- isExact rawinstr;
             extractBinaryOp rawinstr ctx (instruction.bit (bit_op.ashr ex))
      -- and
-     | 27 := extractBinaryOp rawinstr ctx (instruction.bit bit_op.and)
+     | 27 => extractBinaryOp rawinstr ctx (instruction.bit bit_op.and)
      -- or
-     | 28 := extractBinaryOp rawinstr ctx (instruction.bit bit_op.or)
+     | 28 => extractBinaryOp rawinstr ctx (instruction.bit bit_op.or)
      -- xor
-     | 29 := extractBinaryOp rawinstr ctx (instruction.bit bit_op.xor)
+     | 29 => extractBinaryOp rawinstr ctx (instruction.bit bit_op.xor)
 
      -- alloca
-     | 30 := getAllocaData rawinstr >>= λmd,
-          (match md with
-           | none := throw (IO.userError "Expected alloca instruction")
-           | (some (tp, nelts, align)) :=
-           do tp' <- extractType tp,
-              nelts' <- Option.mmap (extractTypedValue ctx) nelts,
-              pure (instruction.alloca tp' nelts' align)
-          )
+     | 30 =>
+       do md ← getAllocaData rawinstr;
+          match md with
+          | none => throw (IO.userError "Expected alloca instruction")
+          | (some (tp, nelts, align)) =>
+            do tp' <- extractType tp;
+               nelts' <- Option.mmap (extractTypedValue ctx) nelts;
+               pure (instruction.alloca tp' nelts' align)
 
      -- load
-     | 31 := getLoadData rawinstr >>= λmd,
-          (match md with
-           | none := throw (IO.userError "Expected load instruction")
-           | (some (ptr, align)) :=
-             do ptr' <- extractTypedValue ctx ptr,
-                pure (instruction.load ptr' none align) -- TODO atomic ordering
-          )
+     | 31 =>
+       do md ← getLoadData rawinstr;
+          match md with
+          | none => throw (IO.userError "Expected load instruction")
+          | (some (ptr, align)) =>
+            do ptr' <- extractTypedValue ctx ptr;
+               pure (instruction.load ptr' none align) -- TODO atomic ordering
 
      -- store
-     | 32 := getStoreData rawinstr >>= λmd,
-          (match md with
-           | none := throw (IO.userError "Expected store instruction")
-           | (some (val,ptr,align)) :=
-           do val' <- extractTypedValue ctx val,
-              ptr' <- extractTypedValue ctx ptr,
+     | 32 =>
+       do md ← getStoreData rawinstr;
+          match md with
+          | none => throw (IO.userError "Expected store instruction")
+          | (some (val,ptr,align)) =>
+           do val' <- extractTypedValue ctx val;
+              ptr' <- extractTypedValue ctx ptr;
               pure (instruction.store val' ptr' align)
-          )
 
      -- trunc
-     | 37 := extractCastOp rawinstr ctx (instruction.conv conv_op.trunc)
+     | 37 => extractCastOp rawinstr ctx (instruction.conv conv_op.trunc)
      -- zext
-     | 38 := extractCastOp rawinstr ctx (instruction.conv conv_op.zext)
+     | 38 => extractCastOp rawinstr ctx (instruction.conv conv_op.zext)
      -- zext
-     | 39 := extractCastOp rawinstr ctx (instruction.conv conv_op.sext)
+     | 39 => extractCastOp rawinstr ctx (instruction.conv conv_op.sext)
      -- fptoui
-     | 40 := extractCastOp rawinstr ctx (instruction.conv conv_op.fp_to_ui)
+     | 40 => extractCastOp rawinstr ctx (instruction.conv conv_op.fp_to_ui)
      -- fptosi
-     | 41 := extractCastOp rawinstr ctx (instruction.conv conv_op.fp_to_si)
+     | 41 => extractCastOp rawinstr ctx (instruction.conv conv_op.fp_to_si)
      -- uitofp
-     | 42 := extractCastOp rawinstr ctx (instruction.conv conv_op.ui_to_fp)
+     | 42 => extractCastOp rawinstr ctx (instruction.conv conv_op.ui_to_fp)
      -- sitofp
-     | 43 := extractCastOp rawinstr ctx (instruction.conv conv_op.si_to_fp)
+     | 43 => extractCastOp rawinstr ctx (instruction.conv conv_op.si_to_fp)
      -- fptrunc
-     | 44 := extractCastOp rawinstr ctx (instruction.conv conv_op.fp_trunc)
+     | 44 => extractCastOp rawinstr ctx (instruction.conv conv_op.fp_trunc)
      -- fpext
-     | 45 := extractCastOp rawinstr ctx (instruction.conv conv_op.fp_ext)
+     | 45 => extractCastOp rawinstr ctx (instruction.conv conv_op.fp_ext)
      -- ptrtoint
-     | 46 := extractCastOp rawinstr ctx (instruction.conv conv_op.ptr_to_int)
+     | 46 => extractCastOp rawinstr ctx (instruction.conv conv_op.ptr_to_int)
      -- inttoptr
-     | 47 := extractCastOp rawinstr ctx (instruction.conv conv_op.int_to_ptr)
+     | 47 => extractCastOp rawinstr ctx (instruction.conv conv_op.int_to_ptr)
      -- bitcast
-     | 48 := extractCastOp rawinstr ctx (instruction.conv conv_op.bit_cast)
+     | 48 => extractCastOp rawinstr ctx (instruction.conv conv_op.bit_cast)
 
      -- icmp
-     | 52 :=
-          do d <- getCmpInstData rawinstr,
-             (match d with
-              | none := throw (IO.userError "expected icmp instruction")
-              | (some (code, (v1, v2))) :=
-                do o1 <- extractTypedValue ctx v1,
-                   o2 <- extractTypedValue ctx v2,
-                   op <- extractICmpOp code,
-                   pure (instruction.icmp op o1 o2.value))
+     | 52 =>
+          do d <- getCmpInstData rawinstr;
+             match d with
+             | none => throw (IO.userError "expected icmp instruction")
+             | (some (code, (v1, v2))) =>
+               do o1 <- extractTypedValue ctx v1;
+                  o2 <- extractTypedValue ctx v2;
+                  op <- extractICmpOp code;
+                  pure (instruction.icmp op o1 o2.value)
 
      -- PHI
-     | 54 :=
-          do t <- getInstructionType rawinstr >>= extractType,
-             d <- getPhiData rawinstr,
-             (match d with
-              | none := throw (IO.userError "expected phi instruction")
-              | some vs :=
-                  do vs' <- Array.mmap (λvbb:(LLVMValue×BasicBlock),
-                             Prod.mk <$> extractValue ctx vbb.1 <*> extractBlockLabel ctx vbb.2) vs,
-                     pure (instruction.phi t vs')
-              )
+     | 54 =>
+          do t <- getInstructionType rawinstr >>= extractType;
+             d <- getPhiData rawinstr;
+             match d with
+             | none => throw (IO.userError "expected phi instruction")
+             | some vs =>
+                 do vs' <- vs.mmap (λvbb:(LLVMValue×BasicBlock) =>
+                            Prod.mk <$> extractValue ctx vbb.1 <*> extractBlockLabel ctx vbb.2);
+                    pure (instruction.phi t vs')
 
      -- select
-     | 56 :=
-          do d <- getSelectInstData rawinstr,
-             (match d with
-              | none := throw (IO.userError "expected select instruction")
-              | (some (vc, (vt,ve))) :=
-                do c <- extractTypedValue ctx vc,
-                   t <- extractTypedValue ctx vt,
-                   e <- extractTypedValue ctx ve,
+     | 56 =>
+          do d <- getSelectInstData rawinstr;
+             match d with
+             | none => throw (IO.userError "expected select instruction")
+             | (some (vc, (vt,ve))) =>
+                do c <- extractTypedValue ctx vc;
+                   t <- extractTypedValue ctx vt;
+                   e <- extractTypedValue ctx ve;
                    pure (instruction.select c t e.value)
-             )
 
-     | _ := throw (IO.userError ("unimplemented instruction opcode: " ++ (Nat.toDigits 10 op).asString))
+     | _ => throw (IO.userError ("unimplemented instruction opcode: " ++ (Nat.toDigits 10 op).asString))
 .
 
 def extractStmt (rawinstr:Instruction) (ctx:value_context) : IO stmt :=
-  do i <- extractInstruction rawinstr ctx,
+  do i <- extractInstruction rawinstr ctx;
      pure (stmt.mk (RBMap.find ctx.imap rawinstr) i Array.empty).
 
 def extractStatements (bb:BasicBlock) (ctx:value_context) : IO (Array stmt) :=
-  do rawinstrs <- getInstructionArray bb,
-     Array.miterate rawinstrs Array.empty (λ_ rawinstr stmts,
-       do stmt <- extractStmt rawinstr ctx,
+  do rawinstrs <- getInstructionArray bb;
+     Array.miterate rawinstrs Array.empty (λ_ rawinstr stmts =>
+       do stmt <- extractStmt rawinstr ctx;
           pure (Array.push stmts stmt)).
 
 def extractBasicBlocks (fn : LLVMFunction) (ctx:value_context) : IO (Array basic_block) :=
-  do rawbbs <- getBasicBlockArray fn,
-     Array.miterate rawbbs Array.empty (λ_ rawbb bs,
+  do rawbbs <- getBasicBlockArray fn;
+     Array.miterate rawbbs Array.empty (λ_ rawbb bs =>
        match RBMap.find ctx.bmap rawbb with
-       | none := throw (IO.userError "unknown basic block")
-       | (some lab) :=
-           do stmts <- extractStatements rawbb ctx,
+       | none => throw (IO.userError "unknown basic block")
+       | (some lab) =>
+           do stmts <- extractStatements rawbb ctx;
               pure (Array.push bs (basic_block.mk lab stmts))
        ).
 
 def extractFunction (fn : LLVMFunction) : IO define :=
-  do nm <- getFunctionName fn,
-     ret <- getReturnType fn >>= extractType,
-     (counter, args) <- extractArgs fn,
-     (bmap, imap) <- computeNumberings counter fn,
+  do nm <- getFunctionName fn;
+     ret <- getReturnType fn >>= extractType;
+     (counter, args) <- extractArgs fn;
+     (bmap, imap) <- computeNumberings counter fn;
 
-     bbs <- extractBasicBlocks fn (value_context.mk args imap bmap),
+     bbs <- extractBasicBlocks fn (value_context.mk args imap bmap);
 
      pure (define.mk
             none -- linkage
@@ -563,16 +557,16 @@ def extractFunction (fn : LLVMFunction) : IO define :=
           ).
 
 def extractDataLayout (m:Module) : IO (List layout_spec) :=
-  do dlstr <- getModuleDataLayoutStr m,
+  do dlstr <- getModuleDataLayoutStr m;
      match parse.run parse.data_layout dlstr with
-     | (Sum.inl (stk,str')) :=
+     | (Sum.inl (stk,str')) =>
           throw (IO.userError ("Could not parse data layout string: " ++ dlstr ++ "  " ++ stk.repr ++ "  " ++ str'))
-     | (Sum.inr dl)  := pure dl.
+     | (Sum.inr dl) => pure dl.
 
 def extractModule (m:Module) : IO module :=
-  do nm <- getModuleIdentifier m,
-     dl <- extractDataLayout m,
-     fns <- getFunctionArray m >>= Array.mmap extractFunction,
+  do nm <- getModuleIdentifier m;
+     dl <- extractDataLayout m;
+     fns <- getFunctionArray m >>= Array.mmap extractFunction;
      pure (module.mk
              (some nm)
              dl

--- a/src/parser.lean
+++ b/src/parser.lean
@@ -6,16 +6,16 @@ import init.data.char
 
 
 namespace Nat.
-  def fromDigitsAux : List ℕ → ℕ → ℕ 
+  def fromDigitsAux : List Nat → Nat → Nat
   | [] n := n
   | (d::ds) n := fromDigitsAux ds (n*10 + d).
 
-  def fromDigits (ds:List ℕ) := fromDigitsAux ds 0.
+  def fromDigits (ds:List Nat) := fromDigitsAux ds 0.
 end Nat.
 
-structure parse (α:Type) := 
+structure parse (α:Type) :=
   (runParse :
-     Π(z:Type),
+     ∀(z:Type),
        (List String → String → z)   /- global failure continuation -/ →
        (List String → String → z)   /- local failure continuation -/ →
        (α → List String → String → z) /- success continuation -/ →
@@ -24,46 +24,46 @@ structure parse (α:Type) :=
 namespace parse.
 
 instance functor : Functor parse :=
-  { map := λa b f (m:parse a), parse.mk (λz kerr kfail k, 
-              m.runParse z kerr kfail (λx, k (f x)))
-  , mapConst := λa b x (m:parse b), parse.mk (λz kerr kfail k, 
-              m.runParse z kerr kfail (λ_, k x))
+  { map := λa b f (m:parse a) => parse.mk (λz kerr kfail k =>
+              m.runParse z kerr kfail (λx => k (f x)))
+  , mapConst := λa b x (m:parse b) => parse.mk (λz kerr kfail k =>
+              m.runParse z kerr kfail (λ_ => k x))
   }.
 
 instance hasPure : HasPure parse :=
-  { pure := λa x, parse.mk (λz kerr kfail k, k x) }.
+  { pure := λa x => parse.mk (λz kerr kfail k => k x) }.
 
 instance hasSeq : HasSeq parse :=
-  { seq := λa b mf mx, parse.mk (λz kerr kfail k,
-             mf.runParse z kerr kfail (λf,
-             mx.runParse z kerr kfail (λx,
+  { seq := λa b mf mx => parse.mk (λz kerr kfail k =>
+             mf.runParse z kerr kfail (λf =>
+             mx.runParse z kerr kfail (λx =>
              k (f x))))
   }.
 
 instance hasSeqLeft : HasSeqLeft parse :=
-  { seqLeft := λa b mx my, parse.mk (λz kerr kfail k,
-             mx.runParse z kerr kfail (λx,
-             my.runParse z kerr kfail (λ_,
+  { seqLeft := λa b mx my => parse.mk (λz kerr kfail k =>
+             mx.runParse z kerr kfail (λx =>
+             my.runParse z kerr kfail (λ_ =>
              k x)))
   }.
 
 instance hasSeqRight : HasSeqRight parse :=
-  { seqRight := λa b mx my, parse.mk (λz kerr kfail k,
-             mx.runParse z kerr kfail (λ_,
-             my.runParse z kerr kfail (λy,
+  { seqRight := λa b mx my => parse.mk (λz kerr kfail k =>
+             mx.runParse z kerr kfail (λ_ =>
+             my.runParse z kerr kfail (λy =>
              k y)))
   }.
 
 instance hasBind : HasBind parse :=
-  { bind := λa b mx mf, parse.mk (λz kerr kfail k,
-              mx.runParse z kerr kfail (λx,
+  { bind := λa b mx mf => parse.mk (λz kerr kfail k =>
+              mx.runParse z kerr kfail (λx =>
                 (mf x).runParse z kerr kfail k))
   }.
 
 instance alternative : Alternative parse :=
-  { failure := λa, parse.mk (λz kerr kfail k, kfail)
-  , orelse  := λa ma mb, parse.mk (λz kerr kfail k stk str,
-      ma.runParse z kerr (λ_ _, mb.runParse z kerr kfail k stk str) k stk str)
+  { failure := λa => parse.mk (λz kerr kfail k => kfail)
+  , orelse  := λa ma mb => parse.mk (λz kerr kfail k stk str =>
+      ma.runParse z kerr (λ_ _ => mb.runParse z kerr kfail k stk str) k stk str)
   }.
 
 instance applicative : Applicative parse := Applicative.mk _.
@@ -71,24 +71,24 @@ instance monad : Monad parse := Monad.mk _.
 
 def run {α} (m:parse α) : String → (List String × String) ⊕ α :=
   m.runParse _
-    (λstk str, Sum.inl (stk,str))
-    (λstk str, Sum.inl (stk,str))
-    (λx stk str, if str.isEmpty then Sum.inr x else Sum.inl (stk,str))
+    (λstk str => Sum.inl (stk,str))
+    (λstk str => Sum.inl (stk,str))
+    (λx stk str => if str.isEmpty then Sum.inr x else Sum.inl (stk,str))
     [].
 
 def describe {α} (msg:String) (m:parse α) : parse α :=
-  parse.mk (λz kerr kfail k stk str,
-    m.runParse z kerr kfail (λx _ str', k x stk str') (msg::stk) str).
+  parse.mk (λz kerr kfail k stk str =>
+    m.runParse z kerr kfail (λx _ str' => k x stk str') (msg::stk) str).
 
 def text (x:String) : parse String :=
-  parse.mk (λz kerr kfail k stk str,
+  parse.mk (λz kerr kfail k stk str =>
     if String.isPrefixOf x str then
       k x stk (String.drop str (x.length))
     else
       kfail (("expected string: " ++ x) :: stk) str).
- 
+
 def char (p:Char → Bool) : parse Char :=
-  parse.mk (λz kerr kfail k stk str,
+  parse.mk (λz kerr kfail k stk str =>
     let c := str.toSubstring.front in
     if ¬str.isEmpty ∧ p c then
       k c stk (String.drop str 1)
@@ -96,67 +96,67 @@ def char (p:Char → Bool) : parse Char :=
       kfail stk str).
 
 def chars (p:Char → Bool) : parse String :=
-  parse.mk (λz kerr kfail k stk str,
+  parse.mk (λz kerr kfail k stk str =>
     let str' := String.takeWhile str p in
     k str' stk (String.drop str (String.length str'))).
 
-def digit : parse ℕ :=
-  describe "digit" $ 
-  do c <- char Char.isDigit,
+def digit : parse Nat :=
+  describe "digit" $
+  do c <- char Char.isDigit;
      pure (c.val.toNat - ('0'.val.toNat))
 
 def commit {α} (m:parse α) : parse α :=
-  parse.mk (λz kerr _kfail k,
+  parse.mk (λz kerr _kfail k =>
     m.runParse z kerr kerr k).
 
 def delimit {α} (m:parse α) : parse α :=
-  parse.mk (λz kerr kfail k,
+  parse.mk (λz kerr kfail k =>
     m.runParse z kfail kfail k)
 
 def opt {α} (default:α) (m:parse α) : parse α :=
-  parse.mk (λz kerr _kfail k stk str,
-    m.runParse z kerr (λ_ _, k default stk str) k stk str).
+  parse.mk (λz kerr _kfail k stk str =>
+    m.runParse z kerr (λ_ _ => k default stk str) k stk str).
 
 def opt' {α} (m:parse α) : parse (Option α) :=
   opt none (some <$> m).
 
 def choosePrefix {α} : List (String × parse α) → parse α :=
-  delimit ∘ List.foldr (λb m, (text b.1 *> commit b.2) <|> m) failure.
+  delimit ∘ List.foldr (λb m => (text b.1 *> commit b.2) <|> m) failure.
 
 partial def manyAux {α} (m:parse α) (z:Type) (someZ : z)
   : (List α → List String → String → z) → List String → String → z
 
 | k stk str :=
-   let kend := λ(_:List String) (_:String), k [] stk str in
-   m.runParse z 
+   let kend := λ(_:List String) (_:String) => k [] stk str in
+   m.runParse z
      kend
      kend
-     (λx, manyAux (λxs, k (x::xs)))
+     (λx => manyAux (λxs => k (x::xs)))
      stk
      str.
 
 def many {α} (m:parse α) : parse (List α) :=
-  parse.mk (λz kerr _kfail, manyAux m z (kerr [] "")).
+  parse.mk (λz kerr _kfail => manyAux m z (kerr [] "")).
 
 def manyOne {α} (m:parse α) : parse (α × List α) :=
-  do x <- m,
-     xs <- many m,
+  do x <- m;
+     xs <- many m;
      pure (x,xs).
 
 def manyOne' {α} (m:parse α) : parse (List α) :=
-  do x <- m,
-     xs <- many m,
+  do x <- m;
+     xs <- many m;
      pure (x::xs).
 
 def sepBy {α β} (m:parse α) (sep:parse β) : parse (List α) :=
   (List.cons <$> m <*> many (sep *> m)).
 
-def nat : parse ℕ := 
+def nat : parse Nat :=
   parse.describe "nat"
     (Nat.fromDigits <$> manyOne' digit).
 
 def eof : parse Unit :=
-  parse.mk (λz kerr kfail k stk str,
+  parse.mk (λz kerr kfail k stk str =>
     if str.isEmpty then k () stk str else kfail ("Expected EOF"::stk) str).
 
 end parse.

--- a/src/simulate.lean
+++ b/src/simulate.lean
@@ -10,15 +10,15 @@ import .type_context
 namespace llvm.
 
 inductive runtime_value
-| int : Πw:ℕ, bv w → runtime_value
+| int (w:Nat) : bv w → runtime_value
 | symbol : symbol → runtime_value
 .
 
 @[reducible]
-def memMap := @RBMap (bv 64) (bv 8) (λx y, decide (x < y)).
+def memMap := @RBMap (bv 64) (bv 8) (λx y => decide (x < y)).
 
 @[reducible]
-def regMap := @RBMap ident runtime_value (λx y, decide (x < y)).
+def regMap := @RBMap ident runtime_value (λx y => decide (x < y)).
 
 structure frame :=
   (locals : regMap)
@@ -47,7 +47,7 @@ structure sim_conts (z:Type) :=
 
 structure sim (a:Type) :=
   (runSim :
-     Π{z:Type},
+     ∀{z:Type},
      (sim_conts z)           /- nonlocal continuations -/ →
      (a → frame → state → z) /- normal continuation -/ →
      (frame → state → z)).
@@ -55,97 +55,97 @@ structure sim (a:Type) :=
 namespace sim.
 
 instance functor : Functor sim :=
-  { map := λa b f (m:sim a), sim.mk (λz conts k,
-      m.runSim conts (λx, k (f x)))
+  { map := λa b f (m:sim a) => sim.mk (λz conts k =>
+      m.runSim conts (λx => k (f x)))
 
-  , mapConst := λa b x (m:sim b), sim.mk (λz conts k,
-      m.runSim conts (λ_, k x))
+  , mapConst := λa b x (m:sim b) => sim.mk (λz conts k =>
+      m.runSim conts (λ_ => k x))
   }.
 
 instance hasPure : HasPure sim :=
-  { pure := λa x, sim.mk (λz _ k, k x) }.
+  { pure := λa x => sim.mk (λz _ k => k x) }.
 
 instance hasSeq : HasSeq sim :=
-  { seq := λa b mf mx, sim.mk (λz conts k,
-          mf.runSim conts (λf,
-          mx.runSim conts (λx,
+  { seq := λa b mf mx => sim.mk (λz conts k =>
+          mf.runSim conts (λf =>
+          mx.runSim conts (λx =>
           k (f x))))
   }.
 
 instance hasSeqLeft : HasSeqLeft sim :=
-  { seqLeft := λa b mx my, sim.mk (λz conts k,
-       mx.runSim conts (λx,
-       my.runSim conts (λ_,
+  { seqLeft := λa b mx my => sim.mk (λz conts k =>
+       mx.runSim conts (λx =>
+       my.runSim conts (λ_ =>
        k x)))
   }.
 
 instance hasSeqRight : HasSeqRight sim :=
-  { seqRight := λa b mx my, sim.mk (λz conts k,
-       mx.runSim conts (λ_,
-       my.runSim conts (λy,
+  { seqRight := λa b mx my => sim.mk (λz conts k =>
+       mx.runSim conts (λ_ =>
+       my.runSim conts (λy =>
        k y)))
   }.
 
 instance hasBind : HasBind sim :=
-  { bind := λa b mx mf, sim.mk (λz conts k,
-       mx.runSim conts (λx, (mf x).runSim conts k))
+  { bind := λa b mx mf => sim.mk (λz conts k =>
+       mx.runSim conts (λx => (mf x).runSim conts k))
   }.
 
 instance applicative : Applicative sim := Applicative.mk _.
 instance monad : Monad sim := Monad.mk _.
 
 instance monadExcept : MonadExcept IO.Error sim :=
-  { throw := λa err, sim.mk (λz conts _k _frm _st, conts.kerr err)
-  , catch := λa m handle, sim.mk (λz conts k frm st,
-      let conts' := { conts with kerr := λerr, (handle err).runSim conts k frm st }
+  { throw := λa err => sim.mk (λz conts _k _frm _st => conts.kerr err)
+  , catch := λa m handle => sim.mk (λz conts k frm st =>
+      let conts' := { conts with kerr := λerr => (handle err).runSim conts k frm st }
       in m.runSim conts' k frm st)
   }.
 
 def setFrame (frm:frame) : sim Unit :=
-  sim.mk (λz _ k _ st, k () frm st).
+  sim.mk (λz _ k _ st => k () frm st).
 
 def getFrame : sim frame :=
-  sim.mk (λz _ k frm st, k frm frm st).
+  sim.mk (λz _ k frm st => k frm frm st).
 
 def modifyFrame (f: frame → frame) : sim Unit :=
-  sim.mk (λz _ k frm st, k () (f frm) st).
+  sim.mk (λz _ k frm st => k () (f frm) st).
 
 def getState : sim state :=
-  sim.mk (λz _ k frm st, k st frm st).
+  sim.mk (λz _ k frm st => k st frm st).
 
 def setState (st:state) : sim Unit :=
-  sim.mk (λz _ k frm _, k () frm st).
+  sim.mk (λz _ k frm _ => k () frm st).
 
 def assignReg (reg:ident) (v:runtime_value) : sim Unit :=
-  modifyFrame (λ frm, { frm with locals := RBMap.insert frm.locals reg v }).
+  modifyFrame (λfrm => { frm with locals := RBMap.insert frm.locals reg v }).
 
 def lookupReg (reg:ident) : sim runtime_value :=
-  do frm <- getFrame,
+  do frm <- getFrame;
      match RBMap.find frm.locals reg with
-     | none     := throw (IO.userError ("unassigned register: " ++ reg.asString))
-     | (some v) := pure v.
+     | none     => throw (IO.userError ("unassigned register: " ++ reg.asString))
+     | (some v) => pure v
 
 def returnVoid {a} : sim a :=
-  sim.mk (λz conts _k _frm st, conts.kret none st).
+  sim.mk (λz conts _k _frm st => conts.kret none st).
 
 def returnValue {a} (v:runtime_value) : sim a :=
-  sim.mk (λz conts _k _frm st, conts.kret (some v) st).
+  sim.mk (λz conts _k _frm st => conts.kret (some v) st).
 
 def jump {a} (l:block_label) : sim a :=
-  sim.mk (λz conts _k frm st, conts.kjump l frm st).
+  sim.mk (λz conts _k frm st => conts.kjump l frm st).
 
 def call (s:symbol) (args:List runtime_value) : sim (Option runtime_value) :=
-  sim.mk (λz conts k frm st, conts.kcall (λv, k v frm) s args st).
+  sim.mk (λz conts k frm st => conts.kcall (λv => k v frm) s args st).
 
 end sim.
 
 def unreachable {a} : sim a := throw (IO.userError "unreachable code!").
 
 def eval_mem_type (t:llvm_type) : sim mem_type :=
-  do st <- sim.getState,
-     match lift_mem_type st.mod.types t with
-     | none := throw (IO.userError "could not lift type")
-     | (some mt) := pure mt.
+  do st <- sim.getState;
+     (match lift_mem_type st.mod.types t with
+      | none => throw (IO.userError "could not lift type")
+      | (some mt) => pure mt)
 
 
 def eval : mem_type → value → sim runtime_value
@@ -160,14 +160,14 @@ def eval : mem_type → value → sim runtime_value
 | _ _ := throw (IO.userError "bad value/type in evaluation")
 
 def eval_typed (tv:typed value) : sim runtime_value :=
-  do mt <- eval_mem_type tv.type,
+  do mt <- eval_mem_type tv.type;
      eval mt tv.value.
 
-def int_op (f:Πw, bv w -> bv w -> sim runtime_value) : runtime_value -> runtime_value -> sim runtime_value
+def int_op (f:∀w, bv w -> bv w -> sim runtime_value) : runtime_value -> runtime_value -> sim runtime_value
 | (runtime_value.int wx vx) (runtime_value.int wy vy) :=
     (match decEq wy wx with
-    | Decidable.isTrue p  := f wx vx (Eq.rec vy p)
-    | Decidable.isFalse _ := throw (IO.userError "expected same-width integer values")
+    | Decidable.isTrue p  => f wx vx (Eq.rec vy p)
+    | Decidable.isFalse _ => throw (IO.userError "expected same-width integer values")
     )
 | _ _ := throw (IO.userError "expected integer arguments to int_op")
 .
@@ -175,44 +175,44 @@ def int_op (f:Πw, bv w -> bv w -> sim runtime_value) : runtime_value -> runtime
 -- TODO, implement overflow checks
 def eval_arith (op:arith_op) (x:runtime_value) (y:runtime_value) : sim runtime_value :=
   match op with
-  | (arith_op.add uof sof) := int_op (λ w a b, pure (runtime_value.int w (@bv.add w a b))) x y
-  | (arith_op.sub uof sof) := int_op (λ w a b, pure (runtime_value.int w (@bv.sub w a b))) x y
-  | (arith_op.mul uof sof) := int_op (λ w a b, pure (runtime_value.int w (@bv.mul w a b))) x y
-  | _ := throw (IO.userError "NYE: unimplemented arithmetic operation").
+  | (arith_op.add uof sof) => int_op (λ w a b => pure (runtime_value.int w (@bv.add w a b))) x y
+  | (arith_op.sub uof sof) => int_op (λ w a b => pure (runtime_value.int w (@bv.sub w a b))) x y
+  | (arith_op.mul uof sof) => int_op (λ w a b => pure (runtime_value.int w (@bv.mul w a b))) x y
+  | _ => throw (IO.userError "NYE: unimplemented arithmetic operation").
 
 def asPred : runtime_value → sim Bool
 | (runtime_value.int _ v) := if v.to_nat = 0 then pure false else pure true
 | _ := throw (IO.userError "expected integer value as predicate")
 
 def eval_icmp (op:icmp_op) : runtime_value → runtime_value → sim runtime_value :=
-  int_op (λw a b,
+  int_op (λw a b =>
     let t := (pure (runtime_value.int 1 (bv.from_nat 1 1)) : sim runtime_value) in
     let f := (pure (runtime_value.int 1 (bv.from_nat 1 0)) : sim runtime_value) in
     match op with
-    | icmp_op.ieq  := if a.to_nat =  b.to_nat then t else f
-    | icmp_op.ine  := if a.to_nat != b.to_nat then t else f
+    | icmp_op.ieq  => if a.to_nat =  b.to_nat then t else f
+    | icmp_op.ine  => if a.to_nat != b.to_nat then t else f
 
-    | icmp_op.iule := if a.to_nat <= b.to_nat then t else f
-    | icmp_op.iult := if a.to_nat <  b.to_nat then t else f
-    | icmp_op.iuge := if a.to_nat >= b.to_nat then t else f
-    | icmp_op.iugt := if a.to_nat >  b.to_nat then t else f
+    | icmp_op.iule => if a.to_nat <= b.to_nat then t else f
+    | icmp_op.iult => if a.to_nat <  b.to_nat then t else f
+    | icmp_op.iuge => if a.to_nat >= b.to_nat then t else f
+    | icmp_op.iugt => if a.to_nat >  b.to_nat then t else f
 
-    | icmp_op.isle := if a.to_int <= b.to_int then t else f
-    | icmp_op.islt := if a.to_int <  b.to_int then t else f
-    | icmp_op.isge := if a.to_int >= b.to_int then t else f
-    | icmp_op.isgt := if a.to_int >  b.to_int then t else f
+    | icmp_op.isle => if a.to_int <= b.to_int then t else f
+    | icmp_op.islt => if a.to_int <  b.to_int then t else f
+    | icmp_op.isge => if a.to_int >= b.to_int then t else f
+    | icmp_op.isgt => if a.to_int >  b.to_int then t else f
   ).
 
 
 def eval_bit (op:bit_op) : runtime_value → runtime_value → sim runtime_value :=
-  int_op (λw a b,
+  int_op (λw a b =>
     match op with
-    | bit_op.and  := pure (runtime_value.int w (@bv.bitwise_and w a b))
-    | bit_op.or   := pure (runtime_value.int w (@bv.bitwise_or w a b))
-    | bit_op.xor  := pure (runtime_value.int w (@bv.bitwise_xor w a b))
-    | (bit_op.shl uov sov) := pure (runtime_value.int w (@bv.shl w a b))
-    | (bit_op.lshr exact)  := pure (runtime_value.int w (@bv.lshr w a b))
-    | (bit_op.ashr exact)  := pure (runtime_value.int w (@bv.ashr w a b))
+    | bit_op.and  => pure (runtime_value.int w (@bv.bitwise_and w a b))
+    | bit_op.or   => pure (runtime_value.int w (@bv.bitwise_or w a b))
+    | bit_op.xor  => pure (runtime_value.int w (@bv.bitwise_xor w a b))
+    | (bit_op.shl uov sov) => pure (runtime_value.int w (@bv.shl w a b))
+    | (bit_op.lshr exact)  => pure (runtime_value.int w (@bv.lshr w a b))
+    | (bit_op.ashr exact)  => pure (runtime_value.int w (@bv.ashr w a b))
   ).
 
 def eval_conv : conv_op → mem_type → runtime_value → mem_type → sim runtime_value
@@ -250,55 +250,54 @@ def evalInstr : instruction → sim (Option runtime_value)
 | (instruction.ret v)    := eval_typed v >>= sim.returnValue
 
 | (instruction.phi tp xs) :=
-     do frm <- sim.getFrame,
-        t  <- eval_mem_type tp,
-        (match frm.prev with
-         | none := throw (IO.userError "phi nodes not allowed in entry block")
-         | (some prv) := some <$> phi t prv xs.toList
-        )
+     do frm <- sim.getFrame;
+        t  <- eval_mem_type tp;
+        match frm.prev with
+        | none => throw (IO.userError "phi nodes not allowed in entry block")
+        | (some prv) => some <$> phi t prv xs.toList
 
 | (instruction.arith op x y) :=
-     do t  <- eval_mem_type x.type,
-        xv <- eval t x.value,
-        yv <- eval t y,
+     do t  <- eval_mem_type x.type;
+        xv <- eval t x.value;
+        yv <- eval t y;
         some <$> eval_arith op xv yv
 
 | (instruction.bit op x y) :=
-     do t  <- eval_mem_type x.type,
-        xv <- eval t x.value,
-        yv <- eval t y,
+     do t  <- eval_mem_type x.type;
+        xv <- eval t x.value;
+        yv <- eval t y;
         some <$> eval_bit op xv yv
 
 | (instruction.conv op x outty) :=
-     do t  <- eval_mem_type x.type,
-        xv <- eval t x.value,
-        t' <- eval_mem_type outty,
+     do t  <- eval_mem_type x.type;
+        xv <- eval t x.value;
+        t' <- eval_mem_type outty;
         some <$> eval_conv op t xv t'
 
 | (instruction.icmp op x y) :=
-     do t  <- eval_mem_type x.type,
-        xv <- eval t x.value,
-        yv <- eval t y,
+     do t  <- eval_mem_type x.type;
+        xv <- eval t x.value;
+        yv <- eval t y;
         some <$> eval_icmp op xv yv
 
 | (instruction.select c x y) :=
-     do cv <- eval_typed c >>= asPred,
-        t  <- eval_mem_type x.type,
-        xv <- eval t x.value,
-        yv <- eval t y,
+     do cv <- eval_typed c >>= asPred;
+        t  <- eval_mem_type x.type;
+        xv <- eval t x.value;
+        yv <- eval t y;
         if cv then pure (some xv) else pure (some yv)
 
 | (instruction.call _tail tp fn args) :=
-     do t <- eval_mem_type tp,
-        fnv <- eval t fn,
-        (match fnv with
-         | runtime_value.symbol s := List.mmap eval_typed args >>= sim.call s
-         | _ := throw (IO.userError "expected symbol value"))
+     do t <- eval_mem_type tp;
+        fnv <- eval t fn;
+        match fnv with
+        | runtime_value.symbol s => List.mmap eval_typed args >>= sim.call s
+        | _ => throw (IO.userError "expected symbol value")
 
 | (instruction.jump l) := sim.jump l
 
 | (instruction.br c lt lf) :=
-     do cv <- eval_typed c >>= asPred,
+     do cv <- eval_typed c >>= asPred;
         if cv then sim.jump lt else sim.jump lf
 
 | (instruction.unreachable) := unreachable
@@ -307,30 +306,30 @@ def evalInstr : instruction → sim (Option runtime_value)
 .
 
 def evalStmt (s:stmt) : sim Unit :=
-  do res <- evalInstr s.instr,
+  do res <- evalInstr s.instr;
      match (s.assign, res) with
-     | (none, _)        := pure ()
-     | (some i, some v) := sim.assignReg i v
-     | (some _, none)   := throw (IO.userError "expected instruction to compute a value").
+     | (none, _)        => pure ()
+     | (some i, some v) => sim.assignReg i v
+     | (some _, none)   => throw (IO.userError "expected instruction to compute a value").
 
-def evalStmts (stmts:Array stmt) : sim Unit :=
-  Array.mfoldl (λ_ s, evalStmt s) Unit.unit stmts.
+partial def evalStmts (stmts:Array stmt) : sim Unit := pure () -- FIXME
+--  @Array.mfoldl Unit stmt sim (λ_ s => evalStmt s) Unit.unit stmts
 
 def findBlock (l:block_label) (func:define) : sim (Array stmt) :=
-  match Array.find func.body (λbb,
+  match Array.find func.body (λbb =>
     match block_label.decideEq bb.label l with
-    | Decidable.isTrue _ := some bb.stmts
-    | Decidable.isFalse _ := none) with
-  | none := throw (IO.userError ("Could not find block: " ++ pp.render (pp_label l)))
-  | some d := pure d.
+    | Decidable.isTrue _ => some bb.stmts
+    | Decidable.isFalse _ => none) with
+  | none => throw (IO.userError ("Could not find block: " ++ pp.render (pp_label l)))
+  | some d => pure d.
 
 def findFunc (s:symbol) (mod:module) : sim define :=
-  match Array.find mod.defines (λd,
+  match Array.find mod.defines (λd =>
     match decEq d.name.symbol s.symbol with
-    | Decidable.isTrue _ := some d
-    | Decidable.isFalse _ := none) with
-  | none := throw (IO.userError ("Could not find function: " ++ s.symbol))
-  | some d := pure d.
+    | Decidable.isTrue _ => some d
+    | Decidable.isFalse _ => none) with
+  | none => throw (IO.userError ("Could not find function: " ++ s.symbol))
+  | some d => pure d.
 
 partial def execBlock {z}
     (_zinh:z)
@@ -346,8 +345,8 @@ partial def execBlock {z}
       , kcall := kcall
       , kjump := execBlock
       }
-      (λ_ _ _, kerr (IO.userError ("expected block terminatror at the end of block: "
-                                  ++ pp.render (pp_label next))))
+      (λ_ _ _ => kerr (IO.userError ("expected block terminatror at the end of block: "
+                                    ++ pp.render (pp_label next))))
       { frm with curr := next, prev := some frm.curr }
       st.
 
@@ -358,17 +357,17 @@ def assignArgs : List (typed ident) → List runtime_value → regMap → sim re
 
 def entryLabel (d:define) : sim block_label :=
   match Array.getOpt d.body 0 with
-  | (some bb) := pure bb.label
-  | none      := throw (IO.userError "definition does not have entry block!").
+  | (some bb) => pure bb.label
+  | none      => throw (IO.userError "definition does not have entry block!").
 
 partial def execFunc {z} (zinh:z) (kerr:IO.Error → z)
   : (Option runtime_value → state → z) → symbol → List runtime_value → state → z
 
 | kret s args st :=
-   (do func   <- findFunc s st.mod,
-       locals <- assignArgs func.args.toList args RBMap.empty,
-       lab    <- entryLabel func,
-       sim.setFrame (frame.mk locals func lab none),
+   (do func   <- findFunc s st.mod;
+       locals <- assignArgs func.args.toList args RBMap.empty;
+       lab    <- entryLabel func;
+       sim.setFrame (frame.mk locals func lab none);
        findBlock lab func >>= evalStmts
    ).runSim
       { kerr  := kerr
@@ -376,11 +375,11 @@ partial def execFunc {z} (zinh:z) (kerr:IO.Error → z)
       , kcall := execFunc
       , kjump := execBlock zinh kerr kret execFunc
       }
-      (λ_ _ _, kerr (IO.userError "unreachable code!"))
+      (λ_ _ _ => kerr (IO.userError "unreachable code!"))
       (default _)
       st.
 
 def runFunc : symbol → List runtime_value → state → IO.Error ⊕ (Option runtime_value × state) :=
-  execFunc (Sum.inl (IO.userError "bottom")) Sum.inl (λov st, Sum.inr (ov,st)).
+  execFunc (Sum.inl (IO.userError "bottom")) Sum.inl (λov st => Sum.inr (ov,st)).
 
 end llvm.

--- a/src/type_context.lean
+++ b/src/type_context.lean
@@ -18,64 +18,64 @@ with sym_type : Type
   | opaque   : sym_type
   | unsupported : llvm_type → sym_type
 
-with mem_type : Type 
+with mem_type : Type
   | ptr      : sym_type → mem_type
-  | int      : ℕ → mem_type
-  | array    : ℕ → mem_type → mem_type
-  | vector   : ℕ → mem_type → mem_type
+  | int      : Nat → mem_type
+  | array    : Nat → mem_type → mem_type
+  | vector   : Nat → mem_type → mem_type
   | struct   : List mem_type → mem_type
   | packed_struct : List mem_type → mem_type
   | metadata : mem_type
 
---  | float    : 
---  | double   : 
---  | x86_fp80 : 
+--  | float    :
+--  | double   :
+--  | x86_fp80 :
 
 with fun_decl : Type
-  | fun_decl : Π(ret : Option mem_type) (args : List mem_type) (varargs : Bool), fun_decl
+  | fun_decl : ∀(ret : Option mem_type) (args : List mem_type) (varargs : Bool), fun_decl
 .
 
 instance : Inhabited sym_type := ⟨sym_type.void⟩
 
 def lookup_td (tds:Array type_decl) (i:String) : Option llvm_type :=
-  Array.find tds (λtd, 
+  Array.find tds (λtd =>
    match decEq td.name i with
-   | Decidable.isTrue _  := some td.value
-   | Decidable.isFalse _ := none
+   | Decidable.isTrue _  => some td.value
+   | Decidable.isFalse _ => none
    ).
 
 partial def lift_sym_type (lift_mem_type : llvm_type → Option mem_type) (tds:Array type_decl) : llvm_type → sym_type
 | t@(llvm_type.prim_type pt) :=
      (match pt with
-     | prim_type.label     := sym_type.unsupported t
-     | prim_type.void      := sym_type.void
-     | prim_type.integer n := sym_type.mem_type (mem_type.int n)
-     | prim_type.metadata  := sym_type.mem_type mem_type.metadata
-     | prim_type.float_type _ := sym_type.unsupported t
-     | prim_type.x86mmx       := sym_type.unsupported t)
+     | prim_type.label     => sym_type.unsupported t
+     | prim_type.void      => sym_type.void
+     | prim_type.integer n => sym_type.mem_type (mem_type.int n)
+     | prim_type.metadata  => sym_type.mem_type mem_type.metadata
+     | prim_type.float_type _ => sym_type.unsupported t
+     | prim_type.x86mmx       => sym_type.unsupported t)
 
 | (llvm_type.alias i) := sym_type.ty_alias i
 
 | t@(llvm_type.fun_ty ret args va) :=
-     let mt : Option fun_decl
-         := lift_mem_type ret >>= λret',
-            List.mmap lift_mem_type args >>= λargs',
+     let mt : Option fun_decl := do
+          lift_mem_type ret >>= λret' =>
+            List.mmap lift_mem_type args >>= λargs' =>
             pure (fun_decl.fun_decl ret' args' va)
      in Option.casesOn mt (sym_type.unsupported t) sym_type.fun_type
 
 | (llvm_type.ptr_to t') := sym_type.mem_type (mem_type.ptr (lift_sym_type t'))
-            
+
 | t@(llvm_type.array n tp) :=
     (match lift_mem_type tp with
-     | none   := sym_type.unsupported t
-     | some m := sym_type.mem_type (mem_type.array n m))
+     | none   => sym_type.unsupported t
+     | some m => sym_type.mem_type (mem_type.array n m))
 
 | t@(llvm_type.vector n tp) :=
     (match lift_mem_type tp with
-     | none   := sym_type.unsupported t
-     | some m := sym_type.mem_type (mem_type.vector n m))
+     | none   => sym_type.unsupported t
+     | some m => sym_type.mem_type (mem_type.vector n m))
 
-| llvm_type.opaque := sym_type.opaque 
+| llvm_type.opaque := sym_type.opaque
 
 | t@(llvm_type.struct fs) :=
      let mt : Option (List mem_type)
@@ -91,18 +91,18 @@ partial def lift_sym_type (lift_mem_type : llvm_type → Option mem_type) (tds:A
 partial def lift_mem_type (tds:Array type_decl) : llvm_type → Option mem_type
 | (llvm_type.prim_type pt) :=
    (match pt with
-    | prim_type.integer n      := some (mem_type.int n)
-    | prim_type.metadata       := some mem_type.metadata
-    | prim_type.label          := none
-    | prim_type.void           := none
-    | prim_type.float_type _   := none
-    | prim_type.x86mmx         := none)
+    | prim_type.integer n      => some (mem_type.int n)
+    | prim_type.metadata       => some mem_type.metadata
+    | prim_type.label          => none
+    | prim_type.void           => none
+    | prim_type.float_type _   => none
+    | prim_type.x86mmx         => none)
 | (llvm_type.ptr_to tp)        := some (mem_type.ptr (lift_sym_type lift_mem_type tds tp))
 | (llvm_type.alias i)          := lookup_td tds i >>= lift_mem_type
 | (llvm_type.struct fs)        := mem_type.struct <$> (List.mmap lift_mem_type fs)
 | (llvm_type.packed_struct fs) := mem_type.packed_struct <$> (List.mmap lift_mem_type fs)
 | (llvm_type.array n tp)       := mem_type.array n <$> lift_mem_type tp
-| (llvm_type.vector n tp)      := mem_type.vector n <$> lift_mem_type tp 
+| (llvm_type.vector n tp)      := mem_type.vector n <$> lift_mem_type tp
 | (llvm_type.fun_ty _ _ _)     := none
 | llvm_type.opaque             := none
 .


### PR DESCRIPTION
After updating to a more recent lean4 build, this eliminates many of the explicit instances in simulate.lean in favor of existing Lean definitions.