### PR TITLE
minor tweak to Makefile path generation

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,4 +1,4 @@
-HERE := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HERE := $(abspath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 LOCALFILES := src/Alignment.lean\
   src/AST.lean\
   src/PP.lean\
@@ -17,9 +17,10 @@ LOCALFILES := src/Alignment.lean\
 LOCAL_CXX := src/llvm_exports.cpp
 
 
-LEANFILES += $(patsubst %,${HERE}%,${LOCALFILES})
-EXTRACXXFILES += $(patsubst %,${HERE}%,${LOCAL_CXX})
-LEAN_PATH := ${LEAN_PATH}:LeanLLVM=${HERE}src/
+LEANFILES += $(patsubst %,${HERE}/%,${LOCALFILES})
+
+EXTRACXXFILES += $(patsubst %,${HERE}/%,${LOCAL_CXX})
+LEAN_PATH := ${LEAN_PATH}:LeanLLVM=${HERE}/src
 
 $(HERE)/src/LLVMCodes.lean : $(HERE)/src/LLVMCodes.lean.in
 	$(CXX) -E -P -I$(LLVM_INCLUDE) -o $@ -x c $<


### PR DESCRIPTION
Tweaks how paths are created/modified in the makefile to ensure (a) no paths contain double slashes or other seemingly innocuous artifacts of how they were generated that can interfere with make target name resolution (i.e., targets `foo/bar` and `foo//bar` are not considered the same, even though most file path-aware systems will treat them as the same file path) and (b) that we don't leave a trailing `/` on file paths just as a consistent convention.