### PR TITLE
bug fix: fix order of addr and val for store

### DIFF
--- a/src/LeanLLVM/AST.lean
+++ b/src/LeanLLVM/AST.lean
@@ -315,7 +315,7 @@ inductive Instruction : Type
 | call (tailcall : Bool) (rtp:Option LLVMType) (fn:Value) (args:Array (Typed Value))
 | alloca (tp:LLVMType) (cnt:Option (Typed Value)) (align:Option Nat)
 | load (addr:Typed Value) (ord:Option AtomicOrdering) (align:Option Nat)
-| store (addr:Typed Value) (val:Typed Value) (align:Option Nat)
+| store (val:Typed Value) (addr:Typed Value) (align:Option Nat)
 /-
 | fence : option string -> atomic_ordering -> instruction
 | cmp_xchg (weak : bool) (volatile : bool) : Typed Value -> Typed Value -> Typed Value


### PR DESCRIPTION
Make the ordering of the parameters to the `store` LLVM instruction consistent with the LLVM instruction's syntax and how the ordering is assumed in other parts of the `lean-llvm` code base, e.g. [here](https://github.com/GaloisInc/lean-llvm/blob/46a14c397c04cfb51861eeb683aff78560492b27/src/LeanLLVM/Simulate.lean#L198) and [here](https://github.com/GaloisInc/lean-llvm/blob/46a14c397c04cfb51861eeb683aff78560492b27/src/LeanLLVM/LLVMLib.lean#L471).