### PR TITLE
feat: make opcode tags less brittle, work with more LLVM versions

### DIFF
--- a/src/LeanLLVM/LLVMFFI.lean
+++ b/src/LeanLLVM/LLVMFFI.lean
@@ -152,8 +152,8 @@ def getInstructionName : @& Instruction -> IO (Option String) := arbitrary
 @[extern 2 "lean_llvm_getInstructionType"]
 def getInstructionType : @& Instruction -> IO Type_ := arbitrary
 
-@[extern 2 "lean_llvm_getInstructionOpcode"]
-def getInstructionOpcode : @& Instruction -> IO Code.Instr := arbitrary
+@[extern 2 "lean_llvm_getInstructionOpcodeName"]
+def getInstructionOpcodeName : @& Instruction -> IO String := arbitrary
 
 @[extern 2 "lean_llvm_getInstructionReturnValue"]
 def getInstructionReturnValue : @& Instruction -> IO (Option Value) := arbitrary

--- a/src/LeanLLVM/LLVMLib.lean
+++ b/src/LeanLLVM/LLVMLib.lean
@@ -357,7 +357,11 @@ def extractICmpOp (n:Code.ICmp) : ICmpOp :=
   | Code.ICmp.sle => ICmpOp.isle
 
 def extractInstruction (rawinstr:FFI.Instruction) (ctx:ValueContext) : extract Instruction := do
-  let op ← (FFI.getInstructionOpcode rawinstr)
+  let op ← do
+    let nm ← FFI.getInstructionOpcodeName rawinstr
+    match Code.Instr.fromOpcodeName nm with
+    | none => throwError $ "unrecovnized LLVM instruction opcode name: " ++ nm
+    | some i => pure i
   let tp ← (FFI.getInstructionType rawinstr) >>= extractType
   match op with
   -- == terminators ==

--- a/src/llvm_exports.cpp
+++ b/src/llvm_exports.cpp
@@ -218,7 +218,12 @@ obj_res allocInstructionObj(obj_res parent, llvm::Instruction* i) {
 
 static
 llvm::Instruction* toInstruction(b_obj_arg o) {
-  return llvm::dyn_cast<llvm::Instruction>(toValue(o));
+  auto pInstr = llvm::dyn_cast<llvm::Instruction>(toValue(o));
+  if(!pInstr) {
+    std::cerr << "dyn_cast to llvm::Instruction failed!" << std::endl;
+    exit(1);
+  }
+  return pInstr;
 }
 
 // llvm::BasicBlock is a subtype of llvm::Value, so we can use the same
@@ -648,10 +653,9 @@ obj_res lean_llvm_getInstructionType(b_obj_arg i_obj, obj_arg r) {
     return io_result_mk_ok(allocTypeObj(i->getType()));
 }
 
-obj_res lean_llvm_getInstructionOpcode(b_obj_arg i_obj, obj_arg r) {
+obj_res lean_llvm_getInstructionOpcodeName(b_obj_arg i_obj, obj_arg r) {
     auto i = toInstruction(i_obj);
-    unsigned int opcode = i->getOpcode();
-    return io_result_mk_ok( box( opcode ) );
+    return io_result_mk_ok( lean_mk_string(i->getOpcodeName()) );
 }
 
 obj_res lean_llvm_getInstructionReturnValue(b_obj_arg i_obj, obj_arg r) {


### PR DESCRIPTION
LLVM opcodes use unsigned integer tags to identify them
(see [llvm/IR/Instruction.def](https://github.com/llvm/llvm-project/blob/2a69790bad1a081d6b89de65331006c674d8781e/llvm/include/llvm/IR/Instruction.def) in LLVM's source), but unfortunately
these can change between LLVM versions. Instead of having lean-llvm
rely on these tags and try to match the Lean implementation's
tags for the equivalent Lean type (i.e., LLVM.Code.Instr) we now
have the instruction emit its opcode name and parse that. These
names appear stable across LLVM versions and thus things won't
unexplicably break if LLVM introduces a new constructor.